### PR TITLE
Make reqHeaders obj literal, fix iSserver typo

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -283,11 +283,11 @@ async function request(method, url, id = undefined, data = undefined, opt = unde
   }
 
   const session = getCookie('swell-session');
-  const reqHeaders = new Headers({
+  const reqHeaders = {
     'Content-Type': 'application/json',
     Authorization: `Basic ${Buffer.from(allOptions.key).toString('base64')}`,
     ...(session ? { 'X-Session': session } : {}),
-  });
+  };
 
   const response = await fetch(reqUrl, {
     method: reqMethod,

--- a/src/card.js
+++ b/src/card.js
@@ -1,6 +1,6 @@
 const { trimStart, trimEnd, toCamel } = require('./utils');
 
-let options = {
+const options = {
   vaultUrl: 'https://vault.schema.io',
   timeout: 20000,
 };
@@ -74,7 +74,7 @@ const api = {
 
     const parts = new String(value).split(/[\s\/\-]+/, 2);
     const month = parts[0];
-    const year = parts[1];
+    let year = parts[1];
 
     // Convert 2 digit year
     if (year && year.length === 2 && /^\d+$/.test(year)) {
@@ -92,7 +92,7 @@ const api = {
   },
 
   types() {
-    var e, t, n, r;
+    let e, t, n, r;
     t = {};
     for (e = n = 40; n <= 49; e = ++n) t[e] = 'Visa';
     for (e = r = 50; r <= 59; e = ++r) t[e] = 'MasterCard';
@@ -110,7 +110,7 @@ const api = {
   },
 
   luhnCheck(num) {
-    var t, n, r, i, s, o;
+    let t, n, r, i, s, o;
     (r = !0), (i = 0), (n = (num + '').split('').reverse());
     for (s = 0, o = n.length; s < o; s++) {
       (t = n[s]), (t = parseInt(t, 10));
@@ -128,7 +128,7 @@ const api = {
   },
 
   validateExpiry(month, year) {
-    var r, i;
+    let r, i;
     return (
       (month = String(month).trim()),
       (year = String(year).trim()),
@@ -222,7 +222,7 @@ function serializeData(data) {
   }
   return s.join('&').replace(' ', '+');
 }
-var rbracket = /\[\]$/;
+const rbracket = /\[\]$/;
 function buildParams(key, obj, add) {
   let name;
   if (obj instanceof Array) {

--- a/src/cookie.js
+++ b/src/cookie.js
@@ -1,18 +1,18 @@
-const { iSserver } = require('./utils');
+const { isServer } = require('./utils');
 
 function getCookie(name) {
-  if (iSserver()) {
+  if (isServer()) {
     return undefined;
   }
 
-  let matches = document.cookie.match(
-    new RegExp('(?:^|; )' + name.replace(/([\.$?*|{}\(\)\[\]\\\/\+^])/g, '\\$1') + '=([^;]*)'),
+  const matches = document.cookie.match(
+    new RegExp('(?:^|; )' + name.replace(/([.$?*|{}()[]\\\/\+^])/g, '\\$1') + '=([^;]*)'),
   );
   return matches ? decodeURIComponent(matches[1]) : undefined;
 }
 
 function setCookie(name, value, options = {}) {
-  if (iSserver()) {
+  if (isServer()) {
     return;
   }
 
@@ -31,9 +31,9 @@ function setCookie(name, value, options = {}) {
 
   let updatedCookie = encodeURIComponent(name) + '=' + encodeURIComponent(value);
 
-  for (let optionKey in options) {
+  for (const optionKey in options) {
     updatedCookie += '; ' + optionKey;
-    let optionValue = options[optionKey];
+    const optionValue = options[optionKey];
 
     if (optionValue !== true) {
       updatedCookie += '=' + optionValue;

--- a/src/utils.js
+++ b/src/utils.js
@@ -31,8 +31,8 @@ function stringifyQuery(str) {
   });
 }
 
-function iSserver() {
-  return !(typeof window != 'undefined' && window.document);
+function isServer() {
+  return !(typeof window !== 'undefined' && window.document);
 }
 
 module.exports = {
@@ -42,5 +42,5 @@ module.exports = {
   trimStart,
   trimEnd,
   stringifyQuery,
-  iSserver,
+  isServer,
 };


### PR DESCRIPTION
The global `Headers` class doesn't exist on node, even with 'isomorphic-fetch' there. This results in a fatal error when using in an SSR context like N*xt. We aren't using any `Headers` methods on the request anyway, so an object literal with the headers should be just fine.

Also fixed the capitalisation of the iSserver variable and some other stuff eslint was complaining about.

NOTE: I couldn't run the test suite because the babel build is trying to reference internal modules that don't exist (e.g. `@babel/runtime/helpers/objectSpread2`), for reasons unknown.