### PR TITLE
Use btoa to base64 encode in browsers.

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -20,6 +20,9 @@ const content = require('./content');
 const settings = require('./settings');
 const payment = require('./payment');
 
+const nodeBtoa = string => Buffer.from(string).toString('base64')
+const base64Encode = typeof btoa !== 'undefined' ? btoa : nodeBtoa
+
 require('isomorphic-fetch');
 
 const options = {
@@ -123,7 +126,7 @@ async function request(method, url, id = undefined, data = undefined, opt = unde
   const session = getCookie('swell-session');
   const reqHeaders = {
     'Content-Type': 'application/json',
-    Authorization: `Basic ${Buffer.from(String(allOptions.key)).toString('base64')}`,
+    Authorization: `Basic ${base64Encode(String(allOptions.key))}`,
     ...(session ? { 'X-Session': session } : {}),
   };
 


### PR DESCRIPTION
Fixes #32 

This use the global `btoa` function if available (as it is in browsers) and otherwise uses `Buffer` for base 64 encoding. As an alternative solution, it could also be a good idea to use a package for this purpose that guarantees to just work in whatever environments you want to support, to kick that concern out of this code base.