### PR TITLE
fix: bind stripe element instance to their events

### DIFF
--- a/src/payment.js
+++ b/src/payment.js
@@ -247,12 +247,12 @@ async function stripeElements(request, payMethods, params) {
     const element = elements.create(type, elementOptions);
     element.mount(elementParams.elementId || `#${type}-element`);
 
-    elementParams.onChange && element.on('change', elementParams.onChange);
-    elementParams.onReady && element.on('ready', elementParams.onReady);
-    elementParams.onFocus && element.on('focus', elementParams.onFocus);
-    elementParams.onBlur && element.on('blur', elementParams.onBlur);
-    elementParams.onEscape && element.on('escape', elementParams.onEscape);
-    elementParams.onClick && element.on('click', elementParams.onClick);
+    elementParams.onChange && element.on('change', elementParams.onChange.bind(element));
+    elementParams.onReady && element.on('ready', elementParams.onReady.bind(element));
+    elementParams.onFocus && element.on('focus', elementParams.onFocus.bind(element));
+    elementParams.onBlur && element.on('blur', elementParams.onBlur.bind(element));
+    elementParams.onEscape && element.on('escape', elementParams.onEscape.bind(element));
+    elementParams.onClick && element.on('click', elementParams.onClick.bind(element));
 
     if (type === 'card' || type === 'cardNumber' || type === 'idealBank') {
       CARD_ELEMENTS.stripe = element;


### PR DESCRIPTION
This allows us to have the [element](https://stripe.com/docs/js/elements_object/get_element) in stripe events:

```ts
swell.payment.createElements({
  card: {
    onReady: function() { // context requires function (not arrow functions)
      console.log('card element ready')
      this.focus() // this is the element instance
    }
  }
})
```

Also work with `separateElements: true`


```ts
swell.payment.createElements({
  card: {
    separateElements: true,
    cardNumber: {
      onReady: function() { // context requires function (not arrow functions)
        console.log('card number element ready')
        this.focus() // this is the element instance
      }
    },
    cardExpiry: {
      onReady: function() { // context requires function (not arrow functions)
        console.log('card expiry element ready')
        // this is the element instance
        this.on('networkschange', () => { })
      }
    },
  }
})
```