### PR TITLE
export SnakeToCamelCase type

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -51,7 +51,7 @@ export * from './subscription';
 
 export as namespace swell;
 
-export type SnakeToCamelCase<S extends string> = S extends `${infer T}_${infer U}`
+export type SnakeToCamelCase<S extends any> = S extends `${infer T}_${infer U}`
   ? `${T}${Capitalize<SnakeToCamelCase<U>>}`
   : S;
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -51,7 +51,7 @@ export * from './subscription';
 
 export as namespace swell;
 
-type SnakeToCamelCase<S extends string> = S extends `${infer T}_${infer U}`
+export type SnakeToCamelCase<S extends string> = S extends `${infer T}_${infer U}`
   ? `${T}${Capitalize<SnakeToCamelCase<U>>}`
   : S;
 


### PR DESCRIPTION
Avoids getting the following error:

```
7:08:41 PM: Error: node_modules/swell-js/types/payment/camel.d.ts:1:10 - error TS2459: Module '".."' declares 'SnakeToCamelCase' locally, but it is not exported.
7:08:41 PM: 
7:08:41 PM: 1 import { SnakeToCamelCase } from '..';
7:08:41 PM:            ~~~~~~~~~~~~~~~~
```