### PR TITLE
[hotfix] Fix CartShipmentRatingSnake type

### DIFF
--- a/types/cart/snake.d.ts
+++ b/types/cart/snake.d.ts
@@ -62,10 +62,11 @@ interface CartShipmentRatingSnake {
     id?: string
     name?: string
     carrier?: string
-    price?: string
+    price?: number
     pickup?: boolean
     tax_code?: string
-  }
+    description?: string
+  }[]
   errors?: [{
     message?: string
     code?: string


### PR DESCRIPTION
Data types that are coming from the API are not consistent with TS types. Wanted to suggest a fix for that.