### PR TITLE
Update `swell.payment.createElements` argument type - fixed typo

### DIFF
--- a/types/payment/snake.d.ts
+++ b/types/payment/snake.d.ts
@@ -57,7 +57,7 @@ interface InputPaymentElementBaseSnake {
 
 interface InputPaymentElementCardSnake extends InputPaymentElementBaseSnake {
   options?: any; // https://stripe.com/docs/js/elements_object/create_element?type=card
-  seperate_elements?: boolean;
+  separate_elements?: boolean;
   card_number?: {
     elementId?: string; // default: #card-element
     options?: object;


### PR DESCRIPTION
`seperate_elements` -> `separate_element`

fixes [!98](https://github.com/swellstores/swell-js/issues/98)

I would not hurt to have this covered by tests 😉 