### PR TITLE
Typdef - specify options for `card_expiry` and `card_cvc`

### DIFF
--- a/types/payment/snake.d.ts
+++ b/types/payment/snake.d.ts
@@ -64,9 +64,11 @@ interface InputPaymentElementCardSnake extends InputPaymentElementBaseSnake {
   };
   card_expiry?: {
     elementId?: string; // default: #cardExpiry-element
+    options?: object;
   };
   card_cvc?: {
     elementId?: string; // default: #cardCvc-element
+    options?: object;
   };
 }
 


### PR DESCRIPTION
Added typedef for options for `card_expiry` and `card_cvc` inputs as well