### PR TITLE
chore: separate creation and mounting of payment buttons

### DIFF
--- a/mocks/payment.js
+++ b/mocks/payment.js
@@ -1,4 +1,10 @@
 const mockPayment = {
+  setElementContainer: function (elementId) {
+    this.elementContainer = document.getElementById(elementId);
+  },
+
+  loadScripts: jest.fn(),
+
   getCart: jest.fn(() => {
     return Promise.resolve({});
   }),
@@ -17,6 +23,10 @@ const mockPayment = {
         return {
           id: 'test_stripe_intent_id',
           client_secret: 'test_stripe_client_secret',
+        };
+      case 'paypal':
+        return {
+          id: 'paypal_order_id',
         };
       default:
         throw new Error(`Unknown gateway: ${gateway}`);

--- a/src/payment/bancontact/stripe.js
+++ b/src/payment/bancontact/stripe.js
@@ -42,6 +42,8 @@ export default class StripeBancontactPayment extends Payment {
   }
 
   async tokenize() {
+    await this.loadScripts(this.scripts);
+
     const cart = await this.getCart();
     const { source, error: sourceError } = await createBancontactSource(
       this.stripe,

--- a/src/payment/card/stripe.js
+++ b/src/payment/card/stripe.js
@@ -43,6 +43,8 @@ export default class StripeCardPayment extends Payment {
   }
 
   async createElements() {
+    await this.loadScripts(this.scripts);
+
     const elements = this.stripe.elements(this.params.config);
 
     if (this.params.separateElements) {
@@ -58,6 +60,8 @@ export default class StripeCardPayment extends Payment {
     if (!this.stripeElement) {
       throw new Error('Stripe payment element is not defined');
     }
+
+    await this.loadScripts(this.scripts);
 
     const cart = await this.getCart();
     const paymentMethod = await createPaymentMethod(
@@ -112,6 +116,8 @@ export default class StripeCardPayment extends Payment {
     if (intent.error) {
       throw new Error(intent.error.message);
     }
+
+    await this.loadScripts(this.scripts);
 
     return this._confirmCardPayment(intent);
   }

--- a/src/payment/google/braintree.js
+++ b/src/payment/google/braintree.js
@@ -3,7 +3,6 @@ import { isLiveMode } from '../../utils';
 import {
   PaymentMethodDisabledError,
   LibraryNotLoadedError,
-  DomElementNotFoundError,
 } from '../../utils/errors';
 
 const API_VERSION = 2;
@@ -87,9 +86,18 @@ export default class BraintreeGooglePayment extends Payment {
   }
 
   async createElements() {
+    const {
+      elementId = 'googlepay-button',
+      locale = 'en',
+      style: { color = 'black', type = 'buy', sizeMode = 'fill' } = {},
+    } = this.params;
+
     if (!this.method.merchant_id) {
       throw new Error('Google merchant ID is not defined');
     }
+
+    this.setElementContainer(elementId);
+    await this.loadScripts(this.scripts);
 
     const isReadyToPay = await this.googleClient.isReadyToPay({
       apiVersion: API_VERSION,
@@ -115,7 +123,24 @@ export default class BraintreeGooglePayment extends Payment {
     const paymentDataRequest =
       googlePayment.createPaymentDataRequest(paymentRequestData);
 
-    this._renderButton(googlePayment, paymentDataRequest);
+    this.element = this.googleClient.createButton({
+      buttonColor: color,
+      buttonType: type,
+      buttonSizeMode: sizeMode,
+      buttonLocale: locale,
+      onClick: this._onClick.bind(this, googlePayment, paymentDataRequest),
+    });
+  }
+
+  mountElements() {
+    const { classes = {} } = this.params;
+    const container = this.elementContainer;
+
+    container.appendChild(this.element);
+
+    if (classes.base) {
+      container.classList.add(classes.base);
+    }
   }
 
   async _createBraintreeClient() {
@@ -159,35 +184,6 @@ export default class BraintreeGooglePayment extends Payment {
         merchantId: this.method.merchant_id,
       },
     };
-  }
-
-  _renderButton(googlePayment, paymentDataRequest) {
-    const {
-      elementId = 'googlepay-button',
-      locale = 'en',
-      style: { color = 'black', type = 'buy', sizeMode = 'fill' } = {},
-      classes = {},
-    } = this.params;
-
-    const container = document.getElementById(elementId);
-
-    if (!container) {
-      throw new DomElementNotFoundError(elementId);
-    }
-
-    if (classes.base) {
-      container.classList.add(classes.base);
-    }
-
-    const button = this.googleClient.createButton({
-      buttonColor: color,
-      buttonType: type,
-      buttonSizeMode: sizeMode,
-      buttonLocale: locale,
-      onClick: this._onClick.bind(this, googlePayment, paymentDataRequest),
-    });
-
-    container.appendChild(button);
   }
 
   async _onClick(googlePayment, paymentDataRequest) {

--- a/src/payment/ideal/stripe.js
+++ b/src/payment/ideal/stripe.js
@@ -54,6 +54,8 @@ export default class StripeIDealPayment extends Payment {
   }
 
   async createElements() {
+    await this.loadScripts(this.scripts);
+
     const elements = this.stripe.elements(this.params.config);
 
     this.stripeElement = createElement('idealBank', elements, this.params);
@@ -63,6 +65,8 @@ export default class StripeIDealPayment extends Payment {
     if (!this.stripeElement) {
       throw new Error('Stripe payment element is not defined');
     }
+
+    await this.loadScripts(this.scripts);
 
     const cart = await this.getCart();
     const { paymentMethod, error: paymentMethodError } =

--- a/src/payment/index.js
+++ b/src/payment/index.js
@@ -53,7 +53,12 @@ export default class PaymentController {
       throw new Error('Payment element parameters are not provided');
     }
 
-    this._performPaymentAction('createElements');
+    const paymentInstances = await this._createPaymentInstances();
+
+    await this._performPaymentAction(paymentInstances, 'createElements').then(
+      (paymentInstances) =>
+        this._performPaymentAction(paymentInstances, 'mountElements'),
+    );
   }
 
   async tokenize(params = this.params) {
@@ -63,7 +68,9 @@ export default class PaymentController {
       throw new Error('Tokenization parameters are not provided');
     }
 
-    this._performPaymentAction('tokenize');
+    const paymentInstances = await this._createPaymentInstances();
+
+    await this._performPaymentAction(paymentInstances, 'tokenize');
   }
 
   async handleRedirect(params = this.params) {
@@ -80,7 +87,14 @@ export default class PaymentController {
     }
 
     removeUrlParams();
-    this._performPaymentAction('handleRedirect', queryParams);
+
+    const paymentInstances = await this._createPaymentInstances();
+
+    await this._performPaymentAction(
+      paymentInstances,
+      'handleRedirect',
+      queryParams,
+    );
   }
 
   async authenticate(id) {
@@ -163,45 +177,70 @@ export default class PaymentController {
     return response;
   }
 
-  async _performPaymentAction(action, ...args) {
+  async _createPaymentInstances() {
     const paymentMethods = await this._getPaymentMethods();
     const params = adjustParams(this.params);
 
-    Object.entries(params).forEach(([method, params]) => {
+    return Object.entries(params).reduce((acc, [method, params]) => {
       const methodSettings = paymentMethods[method];
 
       if (!methodSettings) {
-        return console.error(new PaymentMethodDisabledError(method));
+        console.error(new PaymentMethodDisabledError(method));
+
+        return acc;
       }
 
-      const methodParams = adjustMethodParams(params);
       const PaymentClass = this._getPaymentClass(
         method,
         methodSettings.gateway,
       );
 
       if (!PaymentClass) {
-        return console.error(
+        console.error(
           new UnsupportedPaymentMethodError(method, methodSettings.gateway),
         );
+
+        return acc;
       }
 
+      const methodParams = adjustMethodParams(params);
+
       try {
-        const payment = new PaymentClass(
+        const paymentInstance = new PaymentClass(
           this.request,
           this.options,
           methodParams,
           paymentMethods,
         );
 
-        payment
-          .loadScripts(payment.scripts)
-          .then(payment[action].bind(payment, ...args))
-          .catch(payment.onError.bind(payment));
+        acc.push(paymentInstance);
       } catch (error) {
-        return console.error(error.message);
+        console.error(error.message);
       }
-    });
+
+      return acc;
+    }, []);
+  }
+
+  async _performPaymentAction(paymentInstances, action, ...args) {
+    const nextPaymentInstances = [];
+
+    for (const paymentInstance of paymentInstances) {
+      try {
+        const paymentAction = paymentInstance[action];
+
+        if (paymentAction) {
+          await paymentAction.call(paymentInstance, ...args);
+          nextPaymentInstances.push(paymentInstance);
+        }
+      } catch (error) {
+        const onPaymentError = paymentInstance.onError.bind(paymentInstance);
+
+        onPaymentError(error);
+      }
+    }
+
+    return nextPaymentInstances;
   }
 
   _getPaymentClass(method, gateway) {

--- a/src/payment/index.js
+++ b/src/payment/index.js
@@ -215,7 +215,7 @@ export default class PaymentController {
 
         acc.push(paymentInstance);
       } catch (error) {
-        console.error(error.message);
+        console.error(error);
       }
 
       return acc;

--- a/src/payment/klarna/stripe.js
+++ b/src/payment/klarna/stripe.js
@@ -51,6 +51,9 @@ export default class StripeKlarnaPayment extends Payment {
       gateway: 'stripe',
       intent: getKlarnaIntentDetails(cart),
     });
+
+    await this.loadScripts(this.scripts);
+
     const { error } = await this.stripe.confirmKlarnaPayment(
       intent.client_secret,
       getKlarnaConfirmationDetails(cart),

--- a/src/payment/payment.js
+++ b/src/payment/payment.js
@@ -9,13 +9,44 @@ import {
   cloneDeep,
 } from '../utils';
 import loadScripts from '../utils/script-loader';
+import {
+  DomElementNotFoundError,
+  PaymentElementNotCreatedError,
+} from '../utils/errors';
 
 export default class Payment {
+  _element = null;
+  _elementContainer = null;
+
   constructor(request, options, params, method) {
     this.request = request;
     this.options = options;
     this.params = params;
     this.method = method;
+  }
+
+  get element() {
+    if (!this._element) {
+      throw new PaymentElementNotCreatedError(this.method.name);
+    }
+
+    return this._element;
+  }
+
+  set element(element) {
+    this._element = element;
+  }
+
+  get elementContainer() {
+    return this._elementContainer;
+  }
+
+  setElementContainer(elementId) {
+    this._elementContainer = document.getElementById(elementId);
+
+    if (!this.elementContainer) {
+      throw new DomElementNotFoundError(elementId);
+    }
   }
 
   async loadScripts(scripts) {

--- a/src/payment/payment.js
+++ b/src/payment/payment.js
@@ -25,6 +25,11 @@ export default class Payment {
     this.method = method;
   }
 
+  /**
+   * Returns a payment element.
+   *
+   * @returns {any}
+   */
   get element() {
     if (!this._element) {
       throw new PaymentElementNotCreatedError(this.method.name);
@@ -33,14 +38,29 @@ export default class Payment {
     return this._element;
   }
 
+  /**
+   * Sets a payment element.
+   *
+   * @param {any} element
+   */
   set element(element) {
     this._element = element;
   }
 
+  /**
+   * Returns a HTMLElement container of the payment element.
+   *
+   * @returns {HTMLElement}
+   */
   get elementContainer() {
     return this._elementContainer;
   }
 
+  /**
+   * Sets a HTMLElement container of the payment element.
+   *
+   * @param {string} elementId
+   */
   setElementContainer(elementId) {
     this._elementContainer = document.getElementById(elementId);
 
@@ -49,11 +69,21 @@ export default class Payment {
     }
   }
 
+  /**
+   * Loads payment scripts.
+   *
+   * @param {Array<string | object>} scripts
+   */
   async loadScripts(scripts) {
     await this._populateScriptsParams(scripts);
     await loadScripts(scripts);
   }
 
+  /**
+   * Returns a cart.
+   *
+   * @returns {object}
+   */
   async getCart() {
     const cart = await cartApi(this.request, this.options).get();
 
@@ -64,6 +94,12 @@ export default class Payment {
     return this._adjustCart(cart);
   }
 
+  /**
+   * Updates a cart.
+   *
+   * @param {object} data
+   * @returns {object}
+   */
   async updateCart(data) {
     const updateData = cloneDeep(data);
 
@@ -84,22 +120,51 @@ export default class Payment {
     return this._adjustCart(updatedCart);
   }
 
+  /**
+   * Returns the store settings.
+   *
+   * @returns {object}
+   */
   async getSettings() {
     return settingsApi(this.request, this.options).get();
   }
 
+  /**
+   * Creates a payment intent.
+   *
+   * @param {object} data
+   * @returns {object}
+   */
   async createIntent(data) {
     return this._vaultRequest('post', '/intent', data);
   }
 
+  /**
+   * Updates a payment intent.
+   *
+   * @param {object} data
+   * @returns {object}
+   */
   async updateIntent(data) {
     return this._vaultRequest('put', '/intent', data);
   }
 
+  /**
+   * Authorizes a payment gateway.
+   *
+   * @param {object} data
+   * @returns {object}
+   */
   async authorizeGateway(data) {
     return this._vaultRequest('post', '/authorization', data);
   }
 
+  /**
+   * Calls the onSuccess handler.
+   *
+   * @param {object | undefined} data
+   * @returns {any}
+   */
   onSuccess(data) {
     const successHandler = get(this.params, 'onSuccess');
 
@@ -108,6 +173,11 @@ export default class Payment {
     }
   }
 
+  /**
+   * Calls the onCancel handler.
+   *
+   * @returns {any}
+   */
   onCancel() {
     const cancelHandler = get(this.params, 'onCancel');
 
@@ -116,6 +186,12 @@ export default class Payment {
     }
   }
 
+  /**
+   * Calls the onError handler.
+   *
+   * @param {Error} error
+   * @returns {any}
+   */
   onError(error) {
     const errorHandler = get(this.params, 'onError');
 
@@ -126,10 +202,22 @@ export default class Payment {
     console.error(error.message);
   }
 
+  /**
+   * Adjusts cart data.
+   *
+   * @param {object} cart
+   * @returns {object}
+   */
   async _adjustCart(cart) {
     return this._ensureCartSettings(cart).then(toSnake);
   }
 
+  /**
+   * Sets the store settings to cart.
+   *
+   * @param {object} cart
+   * @returns {object}
+   */
   async _ensureCartSettings(cart) {
     if (cart.settings) {
       return cart;
@@ -140,6 +228,14 @@ export default class Payment {
     return { ...cart, settings: { ...settings.store } };
   }
 
+  /**
+   * Sends a Vault request.
+   *
+   * @param {string} method
+   * @param {string} url
+   * @param {object} data
+   * @returns {object}
+   */
   async _vaultRequest(method, url, data) {
     const response = await vaultRequest(method, url, data);
 
@@ -155,12 +251,22 @@ export default class Payment {
     return response;
   }
 
+  /**
+   * Sets values for payment scripts.
+   *
+   * @param {Array<string | object>} scripts
+   */
   async _populateScriptsParams(scripts = []) {
     for (const script of scripts) {
       await this._populateScriptWithCartParams(script);
     }
   }
 
+  /**
+   * Sets the cart values to the payment script params.
+   *
+   * @param {string | object} script
+   */
   async _populateScriptWithCartParams(script) {
     const cartParams = get(script, 'params.cart');
 

--- a/src/utils/errors.js
+++ b/src/utils/errors.js
@@ -52,3 +52,10 @@ export class DomElementNotFoundError extends Error {
     super(message);
   }
 }
+
+export class PaymentElementNotCreatedError extends Error {
+  constructor(methodName) {
+    const message = `The ${methodName} payment element was not created`;
+    super(message);
+  }
+}

--- a/test/payment/amazon.test.js
+++ b/test/payment/amazon.test.js
@@ -38,7 +38,8 @@ describePayment('payment/amazon', (request, options, paymentMock) => {
       };
 
       global.document = {
-        getElementById: jest.fn(() => ({
+        getElementById: jest.fn((elementId) => ({
+          id: elementId,
           classList: {
             add: jest.fn(),
           },
@@ -59,6 +60,7 @@ describePayment('payment/amazon', (request, options, paymentMock) => {
       );
 
       await payment.createElements();
+      payment.mountElements();
 
       expect(paymentMock.authorizeGateway).toHaveBeenCalledWith({
         gateway: 'amazon',
@@ -108,6 +110,7 @@ describePayment('payment/amazon', (request, options, paymentMock) => {
       );
 
       await payment.createElements();
+      payment.mountElements();
 
       expect(paymentMock.authorizeGateway).toHaveBeenCalledWith({
         gateway: 'amazon',
@@ -155,6 +158,7 @@ describePayment('payment/amazon', (request, options, paymentMock) => {
       );
 
       await payment.createElements();
+      payment.mountElements();
 
       expect(paymentMock.authorizeGateway).toHaveBeenCalledWith({
         gateway: 'amazon',

--- a/test/payment/paypal.test.js
+++ b/test/payment/paypal.test.js
@@ -129,10 +129,11 @@ describePayment('payment/paypal', (request, options, paymentMock) => {
         };
 
         global.document = {
-          getElementById: jest.fn(() => {
+          getElementById: jest.fn((elementId) => {
             addClassMock = jest.fn();
 
             return {
+              id: elementId,
               classList: {
                 add: addClassMock,
               },
@@ -154,6 +155,7 @@ describePayment('payment/paypal', (request, options, paymentMock) => {
         );
 
         await payment.createElements();
+        payment.mountElements();
 
         expect(window.paypal.Buttons).toHaveBeenCalledWith({
           locale: 'de_DE',
@@ -194,6 +196,7 @@ describePayment('payment/paypal', (request, options, paymentMock) => {
         );
 
         await payment.createElements();
+        payment.mountElements();
 
         expect(window.paypal.Buttons).toHaveBeenCalledWith({
           locale: 'en_US',
@@ -731,10 +734,11 @@ describePayment('payment/paypal', (request, options, paymentMock) => {
         };
 
         global.document = {
-          getElementById: jest.fn(() => {
+          getElementById: jest.fn((elementId) => {
             addClassMock = jest.fn();
 
             return {
+              id: elementId,
               classList: {
                 add: addClassMock,
               },
@@ -752,6 +756,7 @@ describePayment('payment/paypal', (request, options, paymentMock) => {
         );
 
         await payment.createElements();
+        payment.mountElements();
 
         expect(window.paypal.Buttons).toHaveBeenCalledWith({
           fundingSource: 'paypal',
@@ -798,6 +803,7 @@ describePayment('payment/paypal', (request, options, paymentMock) => {
         );
 
         await payment.createElements();
+        payment.mountElements();
 
         expect(window.paypal.Buttons).toHaveBeenCalledWith({
           fundingSource: 'paypal',


### PR DESCRIPTION
https://app.asana.com/0/1202306318068147/1204620668660311/f

## Dependencies

- [swell-checkout](https://gitlab.com/schema/swell-checkout/-/merge_requests/203)

## Description
Creation and mounting of payment elements is divided into 2 methods:
- `createElements()` - executes all async calls/requests to create a payment element;
- `mountElements()` - waits for all createElements() calls to complete and mounts the payment elements on the page.