### PR TITLE
feat: add setCookie and getCookie options

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -44,6 +44,8 @@ const api = {
     options.locale = opt.locale;
     options.currency = opt.currency;
     options.api = api;
+    options.getCookie = opt.getCookie || getCookie;
+    options.setCookie = opt.setCookie || setCookie;
     options.getCart = opt.getCart;
     options.updateCart = opt.updateCart;
     utils.setOptions(options);
@@ -113,9 +115,9 @@ async function request(
     ...opt,
   };
 
-  const session = allOptions.session || getCookie('swell-session');
-  const locale = allOptions.locale || getCookie('swell-locale');
-  const currency = allOptions.currency || getCookie('swell-currency');
+  const session = allOptions.session || allOptions.getCookie('swell-session');
+  const locale = allOptions.locale || allOptions.getCookie('swell-locale');
+  const currency = allOptions.currency || allOptions.getCookie('swell-currency');
 
   const baseUrl = `${allOptions.url}${allOptions.base || ''}/api`;
   const reqMethod = String(method).toLowerCase();
@@ -172,7 +174,7 @@ async function request(
   const responseSession = response.headers.get('X-Session');
 
   if (typeof responseSession === 'string' && session !== responseSession) {
-    setCookie('swell-session', responseSession);
+    allOptions.setCookie('swell-session', responseSession);
   }
 
   const result = await response.json();

--- a/src/api.test.js
+++ b/src/api.test.js
@@ -1,5 +1,4 @@
 import api from './api';
-import * as cookie from './cookie';
 
 describe('api', () => {
   beforeEach(() => {
@@ -18,6 +17,8 @@ describe('api', () => {
         vaultUrl: 'https://vault.schema.io',
         useCamelCase: false,
         api: api.options.api,
+        setCookie: api.options.setCookie,
+        getCookie: api.options.getCookie,
       });
     });
   });
@@ -34,6 +35,8 @@ describe('api', () => {
         vaultUrl: 'https://vault.schema.io',
         useCamelCase: false,
         api: api.options.api,
+        setCookie: api.options.setCookie,
+        getCookie: api.options.getCookie,
       });
     });
 
@@ -50,6 +53,8 @@ describe('api', () => {
         vaultUrl: 'https://vault.schema.io',
         useCamelCase: false,
         api: api.options.api,
+        setCookie: api.options.setCookie,
+        getCookie: api.options.getCookie,
       });
     });
   });
@@ -121,7 +126,7 @@ describe('api', () => {
     });
 
     it('updates session cookies', async () => {
-      const setCookieSpy = jest.spyOn(cookie, 'setCookie');
+      const setCookieSpy = jest.spyOn(api.options, 'setCookie');
 
       fetch.mockResponseOnce(JSON.stringify({ data: '123' }), {
         headers: { 'X-Session': 'new-session' },

--- a/src/api.test.js
+++ b/src/api.test.js
@@ -135,6 +135,34 @@ describe('api', () => {
       await api.request('get', '/test');
       expect(setCookieSpy).toHaveBeenCalledWith('swell-session', 'new-session');
     });
+
+    it('should allow custom cookie handler', async () => {
+      const cookies = {}
+
+      const handlers = {
+        getCookie(name) {
+          return cookies[name]
+        },
+        setCookie(name, value) {
+          cookies[name] = value
+        },
+      }
+
+      const setCookieSpy = jest.spyOn(handlers, 'setCookie');
+
+      
+      api.init('test', 'pk_test', {
+        getCookie: handlers.getCookie,
+        setCookie: handlers.setCookie,
+      });
+
+      fetch.mockResponseOnce(JSON.stringify({ data: '123' }), {
+        headers: { 'X-Session': 'new-session' },
+      });
+
+      await api.request('get', '/test');
+      expect(setCookieSpy).toHaveBeenCalledWith('swell-session', 'new-session');
+    });
   });
 
   describe('get', () => {

--- a/src/currency.js
+++ b/src/currency.js
@@ -1,5 +1,4 @@
 import { get, find, round } from './utils';
-import { getCookie, setCookie } from './cookie';
 
 const FORMATTERS = {};
 
@@ -22,7 +21,7 @@ function methods(request, opt) {
     selected() {
       if (!this.code) {
         this.set(
-          getCookie('swell-currency') || opt.api.settings.get('store.currency'),
+          opt.getCookie('swell-currency') || opt.api.settings.get('store.currency'),
         );
       }
 
@@ -50,7 +49,7 @@ function methods(request, opt) {
         ),
       );
 
-      setCookie('swell-currency', code);
+      opt.setCookie('swell-currency', code);
 
       return this.state;
     },

--- a/src/locale.js
+++ b/src/locale.js
@@ -1,5 +1,4 @@
 import { find } from './utils';
-import { getCookie, setCookie } from './cookie';
 
 function methods(request, opt) {
   return {
@@ -12,7 +11,7 @@ function methods(request, opt) {
 
     async select(locale) {
       this.set(locale);
-      setCookie('swell-locale', locale);
+      opt.setCookie('swell-locale', locale);
       opt.api.settings.locale = locale;
       return await request('put', '/session', { locale });
     },
@@ -22,7 +21,7 @@ function methods(request, opt) {
         return this.code;
       }
       const storeLocale = opt.api.settings.getStoreLocale();
-      const cookieLocale = getCookie('swell-locale');
+      const cookieLocale = opt.getCookie('swell-locale');
       opt.api.settings.locale = cookieLocale || storeLocale;
       return cookieLocale || storeLocale;
     },


### PR DESCRIPTION
Closes #82 

---

This PR add `setCookie` and `getCookie` option to swell constructor.

This is a first step required to allow using swell-js with SSR

```js
import swell from 'swell-js'

swell.init('store-id', 'public-key', {
  setCookie: (name, value, options = {}) => {
    // set cookies
  },
  getCookie: (name) => {
    // read cookies

    return 'foo'
  },
})
