### PR TITLE
fix `attributes` types, type in `ProductOptions`

### DIFF
--- a/types/product/snake.d.ts
+++ b/types/product/snake.d.ts
@@ -60,7 +60,7 @@ interface ProductOptionSnake {
     | 'select'
     | 'multi_select'
     | 'file'
-    | 'muti_file';
+    | 'multi_file';
   name?: string;
   parent_id?: string;
   parent_value_ids?: string[];

--- a/types/product/snake.d.ts
+++ b/types/product/snake.d.ts
@@ -124,7 +124,7 @@ interface VariantSnake extends BaseModel {
 
 export interface ProductSnake extends BaseModel {
   active?: boolean;
-  attributes?: Attribute[];
+  attributes?: Record<string, AttributeSnake>;
   bundle?: boolean;
   bundle_items?: Bundle[];
   category?: unknown;


### PR DESCRIPTION
I've updated the type to use `Record` instead because the API returns an object but not an array, fixes #103. I've also fixed a typo in `ProductOptions`