### PR TITLE
Remove npm version script

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,6 @@
     "inject-version": "cross-var replace \"@VERSION@\" $npm_package_version dist/api.js",
     "build": "rollup -c",
     "dev": "rollup -c -w",
-    "version": "npm run build",
     "bump": "npm version patch && npm publish",
     "prepack": "rimraf dist && npm run build",
     "lint": "prettier --write \"{src,types}/**/*.{js,jsx,json,ts}\""


### PR DESCRIPTION
Since `build` script is running during GitHub action (https://github.com/swellstores/swell-js/commit/1a238890b497984db26f0bf50429e87749c82930) it's not necessary to run it from `npm version`