### PR TITLE
fix: correct getOrders return promise

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -137,7 +137,7 @@ export namespace account {
   function getAddresses(input: object): Promise<Address>;
   function getCards(input: object): Promise<Card[]>;
   function getOrder(id: string): Promise<Order>;
-  function getOrders(): ResultsResponse<Promise<Order>>;
+  function getOrders(): Promise<ResultsResponse<Order>>;
   function listAddresses(): Promise<ResultsResponse<Address>>;
   function listCards(): Promise<Card[]>;
   function listOrders(input?: object): Promise<ResultsResponse<Order>>;


### PR DESCRIPTION
When using the `swell.account.getOrders` method I noticed that the return type was incorrect