### PR TITLE
fix: make shipment_weight optional

### DIFF
--- a/types/cart/snake.d.ts
+++ b/types/cart/snake.d.ts
@@ -20,7 +20,7 @@ interface CartItemOptionsSnake {
   id?: string;
   name?: string;
   price?: number;
-  shipment_weight: number;
+  shipment_weight?: number;
   value?: string;
   variant?: boolean;
 }


### PR DESCRIPTION
When using the `CartItemOptions` type I noticed that the type for `shipment_weight` is incorrect. It should be optional.