### PR TITLE
Add missing types for setCookie and getCookie

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -93,6 +93,8 @@ export interface InitOptions {
   useCamelCase?: boolean;
   url?: string;
   vaultUrl?: string;
+  setCookie?: (key: string, value: string) => void;
+  getCookie?: (key: string) => string | undefined;
 }
 
 export interface ResultsResponse<T> {


### PR DESCRIPTION
Add missing type definitions for `setCookie` and `getCookie` functions added in this PR: https://github.com/swellstores/swell-js/pull/115.