### PR TITLE
Fix cache test - open handle w/ record timer

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "webpack-dev-server": "3.11.2"
   },
   "scripts": {
-    "test": "jest --config=jest.config.json",
+    "test": "jest --config=jest.config.json --detectOpenHandles",
     "test:watch": "jest --config=jest.config.json --watch",
     "test:page": "webpack-dev-server --open --config test/page/webpack.config.js",
     "watch": "nodemon --watch src --exec 'npm run build'",

--- a/src/cache.test.js
+++ b/src/cache.test.js
@@ -1,14 +1,21 @@
 import api from './api';
 
 describe('cache', () => {
+  const details = { model: 'pages', id: '1' };
+
   beforeEach(() => {
     api.init('test', 'pk_test');
   });
 
-  describe('setRecord', () => {
+  afterEach(() => {
+    const { recordTimer } = api.cache.values(details);
+    recordTimer?.unref();
+  });
+
+  describe('#setRecord', () => {
     it('should not cause an infinite loop', async () => {
-      api.cache.set({ model: 'pages', id: '1', value: {} });
-      api.cache.setRecord(undefined, { model: 'pages', id: '1' });
+      api.cache.set({ ...details, value: {} });
+      api.cache.setRecord(undefined, details);
 
       const record = api.cache.get('pages', '1');
 
@@ -16,7 +23,7 @@ describe('cache', () => {
     });
   });
 
-  describe('getFetch', () => {
+  describe('#getFetch', () => {
     it('should request from API just once, when cache is enabled', async () => {
       api.cache.options.enabled = true;
       await api.content.get('pages', 'slug');


### PR DESCRIPTION
Problem: The timer in cache test was causing an open handle warning in the `#setRecord` cache test.

Solution: Adds proper test teardown to unref the timer.