### PR TITLE
Fix/stripe intent duplicates

### DIFF
--- a/src/card.test.js
+++ b/src/card.test.js
@@ -1,40 +1,15 @@
-global.fetch = require('jest-fetch-mock');
-global.window = {};
-
 import api from './api';
 
-let VAULT_RESPONSE;
-
 describe('card', () => {
-  let script;
-
   beforeEach(() => {
     api.init('test', 'pk_test');
-    VAULT_RESPONSE = null;
-    // Mock document
-    global.document = {
-      createElement: (tag) => {
-        script = {
-          parentNode: {
-            removeChild: () => {},
-          },
-        };
-        setTimeout(() => {
-          window[`swell_vault_response_${window.__swell_vault_request_id}`]({
-            $data: VAULT_RESPONSE || { token: 't_test' },
-          });
-        }, 100);
-        return script;
-      },
-      getElementsByTagName: (tag) => {
-        return [{ appendChild: (el) => {} }];
-      },
-    };
   });
 
   describe('init', () => {
     describe('createToken', () => {
       it('should make request to POST /tokens', async () => {
+        fetch.mockResponse(JSON.stringify({ $data: { token: 't_test' } }));
+
         await api.card.createToken({
           number: '4242 4242 4242 4242',
           exp_month: 1,
@@ -42,65 +17,59 @@ describe('card', () => {
           cvc: 123,
         });
 
-        expect(script.src).toEqual(
-          'https://vault.schema.io/tokens?%24jsonp%5Bmethod%5D=post&%24jsonp%5Bcallback%5D=swell_vault_response_1&%24data%5Bnumber%5D=4242%204242%204242%204242&%24data%5Bexp_month%5D=1&%24data%5Bexp_year%5D=2099&%24data%5Bcvc%5D=123&%24key=pk_test',
+        expect(fetch).toHaveBeenCalledWith(
+          'https://vault.schema.io/tokens?%24jsonp%5Bmethod%5D=post&%24jsonp%5Bcallback%5D=none&%24data%5Bnumber%5D=4242%204242%204242%204242&%24data%5Bexp_month%5D=1&%24data%5Bexp_year%5D=2099&%24data%5Bcvc%5D=123&%24key=pk_test',
+          expect.objectContaining({
+            signal: expect.any(Object),
+          }),
         );
       });
 
       it('should throw an error if card cvc code is invalid', async () => {
-        try {
-          await api.card.createToken({
+        await expect(
+          api.card.createToken({
             cvc: 1,
-          });
-          throw new Error();
-        } catch (err) {
-          expect(err.message).toEqual('Card CVC code appears to be invalid');
-        }
+          }),
+        ).rejects.toThrow('Card CVC code appears to be invalid');
       });
 
       it('should throw an error if card expiry is invalid', async () => {
-        try {
-          await api.card.createToken({
+        await expect(
+          api.card.createToken({
             cvc: 123,
             exp_month: 100,
-          });
-          throw new Error();
-        } catch (err) {
-          expect(err.message).toEqual('Card expiry appears to be invalid');
-        }
+          }),
+        ).rejects.toThrow('Card expiry appears to be invalid');
       });
 
       it('should throw an error if card number is invalid', async () => {
-        try {
-          await api.card.createToken({
+        await expect(
+          api.card.createToken({
             cvc: 123,
             exp_month: 1,
             exp_year: 2099,
             number: '1',
-          });
-          throw new Error();
-        } catch (err) {
-          expect(err.message).toEqual('Card number appears to be invalid');
-        }
+          }),
+        ).rejects.toThrow('Card number appears to be invalid');
       });
 
       it('should throw an of vault request returns errors', async () => {
-        try {
-          VAULT_RESPONSE = {
-            errors: { gateway: { code: 'INVALID', message: 'Test error' } },
-          };
-          await api.card.createToken({
+        fetch.mockResponse(
+          JSON.stringify({
+            $data: {
+              errors: { gateway: { code: 'INVALID', message: 'Test error' } },
+            },
+          }),
+        );
+
+        await expect(
+          api.card.createToken({
             cvc: 123,
             exp_month: 1,
             exp_year: 2099,
             number: '4242 4242 4242 4242',
-          });
-          throw new Error();
-        } catch (err) {
-          expect(err.message).toEqual('Test error');
-          expect(err.param).toEqual('gateway');
-          expect(err.status).toEqual(402);
-        }
+          }),
+        ).rejects.toThrow('Test error');
       });
     });
 

--- a/src/cart.js
+++ b/src/cart.js
@@ -31,9 +31,12 @@ function methods(request, options) {
 
       const { handler, resolve, reject } = this.pendingRequests.shift();
 
-      return Promise.resolve().then(handler).then(resolve, reject).finally(() => {
-        this.nextRequest();
-      });
+      return Promise.resolve()
+        .then(handler)
+        .then(resolve, reject)
+        .finally(() => {
+          this.nextRequest();
+        });
     },
 
     async requestStateSync(handler) {

--- a/src/cart.test.js
+++ b/src/cart.test.js
@@ -105,17 +105,23 @@ describe('cart', () => {
     it('should execute requests sequentially', async () => {
       fetch
         .mockResponseOnce(
-          () => new Promise((resolve) => {
-            setTimeout(() => resolve({ body: JSON.stringify({
-                ...api.cart.state,
-                grand_total: 1000,
-                index: 1
-              })
-            }), 100);
-          })
+          () =>
+            new Promise((resolve) => {
+              setTimeout(
+                () =>
+                  resolve({
+                    body: JSON.stringify({
+                      ...api.cart.state,
+                      grand_total: 1000,
+                      index: 1,
+                    }),
+                  }),
+                100,
+              );
+            }),
         )
-        .mockResponseOnce(
-          () => Promise.resolve({
+        .mockResponseOnce(() =>
+          Promise.resolve({
             body: JSON.stringify({
               ...api.cart.state,
               waited: true,
@@ -124,28 +130,34 @@ describe('cart', () => {
           }),
         )
         .mockResponseOnce(
-          () => new Promise((resolve) => {
-            setTimeout(() => resolve({ body: JSON.stringify({
-                ...api.cart.state,
-                index: 3
-              })
-            }), 100);
-          })
+          () =>
+            new Promise((resolve) => {
+              setTimeout(
+                () =>
+                  resolve({
+                    body: JSON.stringify({
+                      ...api.cart.state,
+                      index: 3,
+                    }),
+                  }),
+                100,
+              );
+            }),
         )
-        .mockResponseOnce(
-          () => Promise.resolve({
+        .mockResponseOnce(() =>
+          Promise.resolve({
             body: JSON.stringify({
               ...api.cart.state,
               index: 4,
             }),
           }),
         )
-        .mockResponseOnce(
-          () => Promise.resolve({
+        .mockResponseOnce(() =>
+          Promise.resolve({
             body: JSON.stringify({
               ...api.cart.state,
               again: true,
-              index: 5
+              index: 5,
             }),
           }),
         );

--- a/src/currency.js
+++ b/src/currency.js
@@ -21,7 +21,8 @@ function methods(request, opt) {
     selected() {
       if (!this.code) {
         this.set(
-          opt.getCookie('swell-currency') || opt.api.settings.get('store.currency'),
+          opt.getCookie('swell-currency') ||
+            opt.api.settings.get('store.currency'),
         );
       }
 
@@ -65,8 +66,7 @@ function methods(request, opt) {
       const formatCode = params.code || code;
       const formatRate = params.rate || rate;
       const formatLocale = params.locale || this.locale;
-      const formatDecimals =
-        'decimals' in params ? params.decimals : decimals;
+      const formatDecimals = 'decimals' in params ? params.decimals : decimals;
       const { convert = true } = params;
 
       let formatAmount = amount;
@@ -167,8 +167,8 @@ function methods(request, opt) {
               ? 'up'
               : 'down'
             : diff <= -0.5
-            ? 'down'
-            : 'up'
+              ? 'down'
+              : 'up'
           : config.round;
 
       switch (direction) {

--- a/src/payment/google/braintree.js
+++ b/src/payment/google/braintree.js
@@ -187,9 +187,8 @@ export default class BraintreeGooglePayment extends Payment {
 
   async _onClick(googlePayment, paymentDataRequest) {
     try {
-      const paymentData = await this.googleClient.loadPaymentData(
-        paymentDataRequest,
-      );
+      const paymentData =
+        await this.googleClient.loadPaymentData(paymentDataRequest);
 
       if (paymentData) {
         await this._submitPayment(googlePayment, paymentData);

--- a/src/products.js
+++ b/src/products.js
@@ -196,8 +196,8 @@ function findPurchaseOption(product, purchaseOption) {
     typeof purchaseOption === 'string'
       ? purchaseOption
       : plan !== undefined
-      ? 'subscription'
-      : 'standard',
+        ? 'subscription'
+        : 'standard',
   );
   let option = get(product, `purchase_options.${type}`);
   if (!option && type !== 'standard') {

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -1,45 +1,9 @@
-global.fetch = require('jest-fetch-mock');
-global.window = {};
-
 import api from './api';
-import { vaultRequest, toCamel, toSnake, stringifyQuery } from './utils';
+import { toCamel, toSnake, stringifyQuery } from './utils';
 
 describe('utils', () => {
-  let script;
-
   beforeEach(() => {
     api.init('test', 'pk_test');
-    // Mock document
-    global.document = {
-      createElement: (tag) => {
-        script = {
-          parentNode: {
-            removeChild: () => {},
-          },
-        };
-        setTimeout(() => {
-          window[`swell_vault_response_${window.__swell_vault_request_id}`]({
-            $data: { ok: 1 },
-          });
-        }, 100);
-        return script;
-      },
-      getElementsByTagName: (tag) => {
-        return [{ appendChild: (el) => {} }];
-      },
-    };
-  });
-
-  describe('init', () => {
-    describe('vaultRequest', () => {
-      it('should make a fetch request with vaultUrl', async () => {
-        await vaultRequest('post', '/tokens');
-
-        expect(script.src).toEqual(
-          'https://vault.schema.io/tokens?%24jsonp%5Bmethod%5D=post&%24jsonp%5Bcallback%5D=swell_vault_response_1&%24data=&%24key=pk_test',
-        );
-      });
-    });
   });
 
   describe('toCamel', () => {

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -188,7 +188,9 @@ async function vaultRequest(method, url, data) {
     connectionError.status = result?.$status;
 
     throw connectionError;
-  } else return result.$data;
+  }
+
+  return result.$data;
 }
 
 function serializeData(data) {

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -135,64 +135,60 @@ function defaultMethods(request, uri, methods) {
   };
 }
 
-async function vaultRequest(method, url, data, opt = undefined) {
-  const vaultUrl = options.vaultUrl;
-  const timeout = options.timeout;
-  const requestId = vaultRequestId();
-  const callback = `swell_vault_response_${requestId}`;
-
-  data = {
+async function vaultRequest(method, url, data) {
+  const { vaultUrl, timeout, key } = options;
+  const requestData = {
     $jsonp: {
       method,
-      callback,
+      callback: 'none',
     },
     $data: data,
-    $key: options.key,
+    $key: key,
   };
+  const requestUrl = `${trimEnd(vaultUrl)}/${trimStart(url)}?${serializeData(
+    requestData,
+  )}`;
 
-  return new Promise((resolve, reject) => {
-    const script = document.createElement('script');
-    script.type = 'text/javascript';
-    script.src = `${trimEnd(vaultUrl)}/${trimStart(url)}?${serializeData(
-      data,
-    )}`;
+  const abortController = new AbortController();
+  const id = setTimeout(() => abortController.abort(), timeout);
 
-    const errorTimeout = setTimeout(() => {
-      window[callback]({
-        $error: `Request timed out after ${timeout / 1000} seconds`,
-        $status: 500,
-      });
-    }, timeout);
-
-    window[callback] = (result) => {
-      clearTimeout(errorTimeout);
-      if (result && result.$error) {
-        const err = new Error(result.$error);
-        err.code = 'request_error';
-        err.status = result.$status;
-        reject(err);
-      } else if (!result || result.$status >= 300) {
-        const err = new Error(
-          'A connection error occurred while making the request',
+  const result = await fetch(requestUrl, {
+    signal: abortController.signal,
+  })
+    .then((response) => response.json())
+    .catch((error) => {
+      if (error.name === 'AbortError') {
+        const timeoutError = new Error(
+          `Request timed out after ${timeout / 1000} seconds`,
         );
-        err.code = 'connection_error';
-        err.status = result.$status;
-        reject(err);
-      } else {
-        resolve(result.$data);
+
+        timeoutError.status = 500;
+
+        throw timeoutError;
       }
-      delete window[callback];
-      script.parentNode.removeChild(script);
-    };
 
-    document.getElementsByTagName('head')[0].appendChild(script);
-  });
-}
+      throw new Error(error.message);
+    });
 
-function vaultRequestId() {
-  window.__swell_vault_request_id = window.__swell_vault_request_id || 0;
-  window.__swell_vault_request_id++;
-  return window.__swell_vault_request_id;
+  clearTimeout(id);
+
+  if (result?.$error) {
+    const requestError = new Error(result.$error);
+
+    requestError.code = 'request_error';
+    requestError.status = result.$status;
+
+    throw requestError;
+  } else if (!result || result.$status >= 300) {
+    const connectionError = new Error(
+      'A connection error occurred while making the request',
+    );
+
+    connectionError.code = 'connection_error';
+    connectionError.status = result?.$status;
+
+    throw connectionError;
+  } else return result.$data;
 }
 
 function serializeData(data) {
@@ -212,7 +208,9 @@ function serializeData(data) {
   }
   return s.join('&').replace(' ', '+');
 }
+
 const rbracket = /\[\]$/;
+
 function buildParams(key, obj, add) {
   let name;
   if (obj instanceof Array) {

--- a/src/utils/index.test.js
+++ b/src/utils/index.test.js
@@ -1,7 +1,7 @@
-import { loadScript } from './index';
+import { loadScript, vaultRequest, setOptions } from './index';
 
 describe('utils/index', () => {
-  describe('loadScript', () => {
+  describe('#loadScript', () => {
     beforeEach(() => {
       // Mock document
       global.headScripts = [];
@@ -60,6 +60,84 @@ describe('utils/index', () => {
         'data-partner-attribution-id',
         'SwellCommerce_SP',
       );
+    });
+  });
+
+  describe('#vaultRequest', () => {
+    let vaultUrl;
+    let timeout;
+    let key;
+
+    beforeEach(() => {
+      vaultUrl = 'https://vault.schema.io';
+      timeout = 10000;
+      key = 'pk_test';
+
+      setOptions({ vaultUrl, timeout, key });
+
+      fetch.mockResponse(
+        JSON.stringify({
+          $data: { test: 'test-field' },
+          $status: 200,
+        }),
+      );
+    });
+
+    it('should send vault request', async () => {
+      const result = await vaultRequest('post', '/intent', {
+        gateway: 'stripe',
+        intent: { amount: 100, payment_method: 'pm_test' },
+      });
+
+      expect(result).toEqual({ test: 'test-field' });
+      expect(fetch).toHaveBeenCalledWith(
+        'https://vault.schema.io/intent?%24jsonp%5Bmethod%5D=post&%24jsonp%5Bcallback%5D=none&%24data%5Bgateway%5D=stripe&%24data%5Bintent%5D%5Bamount%5D=100&%24data%5Bintent%5D%5Bpayment_method%5D=pm_test&%24key=pk_test',
+        expect.objectContaining({
+          signal: expect.any(Object),
+        }),
+      );
+    });
+
+    it('should throw an error when the response is empty', async () => {
+      fetch.mockResponse(JSON.stringify(''));
+
+      await expect(() =>
+        vaultRequest('post', '/intent', {
+          gateway: 'stripe',
+          intent: { amount: 100, payment_method: 'pm_test' },
+        }),
+      ).rejects.toThrow('A connection error occurred while making the request');
+    });
+
+    it('should throw an error when the response status is >= 300', async () => {
+      fetch.mockResponse(
+        JSON.stringify({
+          $status: 400,
+        }),
+      );
+
+      await expect(() =>
+        vaultRequest('post', '/intent', {
+          gateway: 'stripe',
+          intent: { amount: 100, payment_method: 'pm_test' },
+        }),
+      ).rejects.toThrow('A connection error occurred while making the request');
+    });
+
+    it('should throw an error when the response contains $error', async () => {
+      fetch.mockResponse(
+        JSON.stringify({
+          $status: 200,
+          $error: 'Test Error',
+        }),
+      );
+
+      await expect(() =>
+        vaultRequest('post', '/intent', {
+          gateway: 'stripe',
+          intent: { amount: 100, payment_method: 'pm_test' },
+        }),
+      ).rejects.toThrow('Test Error');
     });
   });
 });

--- a/src/utils/stripe.js
+++ b/src/utils/stripe.js
@@ -99,8 +99,8 @@ function setBancontactOwner(source, data) {
     ...(billingData.phone
       ? { phone: billingData.phone }
       : account.phone
-      ? { phone: account.phone }
-      : {}),
+        ? { phone: account.phone }
+        : {}),
     ...(!isEmpty(billingAddress) ? { address: billingAddress } : {}),
   };
 }


### PR DESCRIPTION
https://app.asana.com/0/1202306318068147/1206492754384816/f

## Description

- [schema-api-server](https://gitlab.com/schema/schema-api-server/-/merge_requests/1300)
- [swell-checkout](https://gitlab.com/schema/swell-checkout/-/merge_requests/231)

During the investigation, it turned out that some browser extensions led to the duplication of all Vault requests (not only POST /intents). Vault requests are executed using JSONP, which may not work correctly due to browser extensions.
The fix is to use the `fetch` instead of `<script src="***" />` request.

## Testing

- Added unit tests for the `vaultRequest` function.

## Risk Assessment

- [ ] This code change is higher risk

<details>
  <summary>What is considered higher risk?</summary>
  <br />

- a regression would negatively impact many customers / core functionality, e.g.,
  - model framework
  - pricing / accounting / billing
  - payment integration
  - shared components
- changes can't be undone so easily, e.g.,
  - API endpoint or model changes
  - destructive actions (e.g. deletes)
  - migration on large # of collections/documents
</details>

## For Reviewers

This code has been reviewed for:

- [ ] Technical approach
- [ ] Risk assessment
- [ ] Dependencies
- [ ] Security
- [ ] Test plan & coverage
- [ ] Code organization
- [ ] Code-style