### PR TITLE
fix: zip_check after creating stripe payment method

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,6 @@
 {
   "bracketSpacing": true,
-  "bracketSameLine": true,
+  "bracketSameLine": false,
   "trailingComma": "all",
   "arrowParens": "always",
   "printWidth": 80,

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "@rollup/plugin-json": "6.1.0",
         "@rollup/plugin-node-resolve": "15.2.3",
         "@rollup/plugin-replace": "5.0.5",
+        "@stripe/stripe-js": "^3.1.0",
         "@types/jest": "^29.5.11",
         "babel-jest": "^29.5.0",
         "babel-loader": "^9.1.3",
@@ -4505,6 +4506,15 @@
       "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/@stripe/stripe-js": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-3.1.0.tgz",
+      "integrity": "sha512-7+ciE35i8NZ6l4FiO1qFkBoZ64ul6B2ZhBVyygB+e/2EZa2WLUyjoxrP53SagnUW7+/q25nDyDLzQq5F0ebOEw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.16"
       }
     },
     "node_modules/@tootallnate/once": {
@@ -25391,6 +25401,12 @@
       "requires": {
         "@sinonjs/commons": "^3.0.0"
       }
+    },
+    "@stripe/stripe-js": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-3.1.0.tgz",
+      "integrity": "sha512-7+ciE35i8NZ6l4FiO1qFkBoZ64ul6B2ZhBVyygB+e/2EZa2WLUyjoxrP53SagnUW7+/q25nDyDLzQq5F0ebOEw==",
+      "dev": true
     },
     "@tootallnate/once": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@rollup/plugin-json": "6.1.0",
     "@rollup/plugin-node-resolve": "15.2.3",
     "@rollup/plugin-replace": "5.0.5",
+    "@stripe/stripe-js": "^3.1.0",
     "@types/jest": "^29.5.11",
     "babel-jest": "^29.5.0",
     "babel-loader": "^9.1.3",

--- a/src/payment/apple/stripe.js
+++ b/src/payment/apple/stripe.js
@@ -186,6 +186,7 @@ export default class StripeApplePayment extends Payment {
           gateway: 'stripe',
           token: paymentMethod,
           brand: card.brand,
+          display_brand: card.display_brand,
           exp_month: card.exp_month,
           exp_year: card.exp_year,
           last4: card.last4,

--- a/src/payment/apple/stripe.js
+++ b/src/payment/apple/stripe.js
@@ -5,6 +5,9 @@ import {
   LibraryNotLoadedError,
 } from '../../utils/errors';
 
+/** @typedef {import('@stripe/stripe-js').Stripe} Stripe */
+/** @typedef {import('@stripe/stripe-js').PaymentRequestPaymentMethodEvent} PaymentRequestPaymentMethodEvent */
+
 export default class StripeApplePayment extends Payment {
   constructor(request, options, params, methods) {
     if (!methods.card) {
@@ -23,6 +26,7 @@ export default class StripeApplePayment extends Payment {
     return ['stripe-js'];
   }
 
+  /** @returns {Stripe} */
   get stripe() {
     if (!StripeApplePayment.stripe) {
       if (window.Stripe) {
@@ -37,6 +41,7 @@ export default class StripeApplePayment extends Payment {
     return StripeApplePayment.stripe;
   }
 
+  /** @param {Stripe} stripe */
   set stripe(stripe) {
     StripeApplePayment.stripe = stripe;
   }
@@ -117,6 +122,7 @@ export default class StripeApplePayment extends Payment {
     return paymentRequest;
   }
 
+  /** @param {import('@stripe/stripe-js').PaymentRequestShippingAddressEvent} event */
   async _onShippingAddressChange(event) {
     const { shippingAddress, updateWith } = event;
     const shipping = this._mapShippingAddress(shippingAddress);
@@ -135,6 +141,7 @@ export default class StripeApplePayment extends Payment {
     }
   }
 
+  /** @param {import('@stripe/stripe-js').PaymentRequestShippingOptionEvent} event */
   async _onShippingOptionChange(event) {
     const { shippingOption, updateWith } = event;
     const cart = await this.updateCart({
@@ -151,6 +158,7 @@ export default class StripeApplePayment extends Payment {
     }
   }
 
+  /** @param {PaymentRequestPaymentMethodEvent} event */
   async _onPaymentMethod(event) {
     const {
       payerEmail,
@@ -193,6 +201,7 @@ export default class StripeApplePayment extends Payment {
     this.onSuccess();
   }
 
+  /** @param {import('@stripe/stripe-js').PaymentRequestShippingAddress} [address] */
   _mapShippingAddress(address = {}) {
     return {
       name: address.recipient,
@@ -206,6 +215,7 @@ export default class StripeApplePayment extends Payment {
     };
   }
 
+  /** @param {PaymentRequestPaymentMethodEvent['paymentMethod']['billing_details']} [address] */
   _mapBillingAddress(address = {}) {
     return {
       name: address.name,

--- a/src/payment/bancontact/stripe.js
+++ b/src/payment/bancontact/stripe.js
@@ -5,6 +5,8 @@ import {
   LibraryNotLoadedError,
 } from '../../utils/errors';
 
+/** @typedef {import('@stripe/stripe-js').Stripe} Stripe */
+
 export default class StripeBancontactPayment extends Payment {
   constructor(request, options, params, methods) {
     if (!methods.card) {
@@ -23,6 +25,7 @@ export default class StripeBancontactPayment extends Payment {
     return ['stripe-js'];
   }
 
+  /** @returns {Stripe} */
   get stripe() {
     if (!StripeBancontactPayment.stripe) {
       if (window.Stripe) {
@@ -37,6 +40,7 @@ export default class StripeBancontactPayment extends Payment {
     return StripeBancontactPayment.stripe;
   }
 
+  /** @param {Stripe} stripe */
   set stripe(stripe) {
     StripeBancontactPayment.stripe = stripe;
   }

--- a/src/payment/card/stripe.js
+++ b/src/payment/card/stripe.js
@@ -7,6 +7,10 @@ import {
 } from '../../utils/stripe';
 import { LibraryNotLoadedError } from '../../utils/errors';
 
+/** @typedef {import('@stripe/stripe-js').Stripe} Stripe */
+/** @typedef {import('@stripe/stripe-js').StripeCardElement} StripeCardElement */
+/** @typedef {import('@stripe/stripe-js').StripeCardNumberElement} StripeCardNumberElement */
+
 export default class StripeCardPayment extends Payment {
   constructor(request, options, params, methods) {
     super(request, options, params, methods.card);
@@ -16,6 +20,7 @@ export default class StripeCardPayment extends Payment {
     return ['stripe-js'];
   }
 
+  /** @returns {Stripe} */
   get stripe() {
     if (!StripeCardPayment.stripe) {
       if (window.Stripe) {
@@ -30,14 +35,17 @@ export default class StripeCardPayment extends Payment {
     return StripeCardPayment.stripe;
   }
 
+  /** @param {Stripe} stripe */
   set stripe(stripe) {
     StripeCardPayment.stripe = stripe;
   }
 
+  /** @returns {StripeCardElement | StripeCardNumberElement} */
   get stripeElement() {
     return StripeCardPayment.stripeElement;
   }
 
+  /** @param {StripeCardElement | StripeCardNumberElement} stripeElement */
   set stripeElement(stripeElement) {
     StripeCardPayment.stripeElement = stripeElement;
   }

--- a/src/payment/google/stripe.js
+++ b/src/payment/google/stripe.js
@@ -5,6 +5,9 @@ import {
   PaymentMethodDisabledError,
 } from '../../utils/errors';
 
+/** @typedef {import('@stripe/stripe-js').Stripe} Stripe */
+/** @typedef {import('@stripe/stripe-js').PaymentRequestPaymentMethodEvent} PaymentRequestPaymentMethodEvent */
+
 export default class StripeGooglePayment extends Payment {
   constructor(request, options, params, methods) {
     if (!methods.card) {
@@ -23,6 +26,7 @@ export default class StripeGooglePayment extends Payment {
     return ['stripe-js'];
   }
 
+  /** @returns {Stripe} */
   get stripe() {
     if (!StripeGooglePayment.stripe) {
       if (window.Stripe) {
@@ -37,6 +41,7 @@ export default class StripeGooglePayment extends Payment {
     return StripeGooglePayment.stripe;
   }
 
+  /** @param {Stripe} stripe */
   set stripe(stripe) {
     StripeGooglePayment.stripe = stripe;
   }
@@ -94,6 +99,7 @@ export default class StripeGooglePayment extends Payment {
     return paymentRequest;
   }
 
+  /** @param {import('@stripe/stripe-js').PaymentRequestShippingAddressEvent} event */
   async _onShippingAddressChange(event) {
     const { shippingAddress, updateWith } = event;
     const shipping = this._mapShippingAddress(shippingAddress);
@@ -112,6 +118,7 @@ export default class StripeGooglePayment extends Payment {
     }
   }
 
+  /** @param {import('@stripe/stripe-js').PaymentRequestShippingOptionEvent} event */
   async _onShippingOptionChange(event) {
     const { shippingOption, updateWith } = event;
     const cart = await this.updateCart({
@@ -128,6 +135,7 @@ export default class StripeGooglePayment extends Payment {
     }
   }
 
+  /** @param {PaymentRequestPaymentMethodEvent} event */
   async _onPaymentMethod(event) {
     const {
       payerEmail,
@@ -170,8 +178,11 @@ export default class StripeGooglePayment extends Payment {
     this.onSuccess();
   }
 
-  // Provides backward compatibility with Google Pay button options
-  // https://developers.google.com/pay/api/web/reference/request-objects#ButtonOptions
+  /**
+   * Provides backward compatibility with Google Pay button options
+   *
+   * @see {@link https://developers.google.com/pay/api/web/reference/request-objects#ButtonOptions}
+   */
   _getButtonStyles() {
     let { style: { color = 'dark', type = 'default', height = '45px' } = {} } =
       this.params;
@@ -201,6 +212,7 @@ export default class StripeGooglePayment extends Payment {
     };
   }
 
+  /** @param {import('@stripe/stripe-js').PaymentRequestShippingAddress} [address] */
   _mapShippingAddress(address = {}) {
     return {
       name: address.recipient,
@@ -214,6 +226,7 @@ export default class StripeGooglePayment extends Payment {
     };
   }
 
+  /** @param {PaymentRequestPaymentMethodEvent['paymentMethod']['billing_details']} [address] */
   _mapBillingAddress(address = {}) {
     return {
       name: address.name,

--- a/src/payment/google/stripe.js
+++ b/src/payment/google/stripe.js
@@ -163,6 +163,7 @@ export default class StripeGooglePayment extends Payment {
           gateway: 'stripe',
           token: paymentMethod,
           brand: card.brand,
+          display_brand: card.display_brand,
           exp_month: card.exp_month,
           exp_year: card.exp_year,
           last4: card.last4,

--- a/src/payment/ideal/stripe.js
+++ b/src/payment/ideal/stripe.js
@@ -9,6 +9,9 @@ import {
   LibraryNotLoadedError,
 } from '../../utils/errors';
 
+/** @typedef {import('@stripe/stripe-js').Stripe} Stripe */
+/** @typedef {import('@stripe/stripe-js').StripeIdealBankElement} StripeIdealBankElement */
+
 export default class StripeIDealPayment extends Payment {
   constructor(request, options, params, methods) {
     if (!methods.card) {
@@ -27,6 +30,7 @@ export default class StripeIDealPayment extends Payment {
     return ['stripe-js'];
   }
 
+  /** @returns {Stripe} */
   get stripe() {
     if (!StripeIDealPayment.stripe) {
       if (window.Stripe) {
@@ -41,14 +45,17 @@ export default class StripeIDealPayment extends Payment {
     return StripeIDealPayment.stripe;
   }
 
+  /** @param {Stripe} stripe */
   set stripe(stripe) {
     StripeIDealPayment.stripe = stripe;
   }
 
+  /** @returns {StripeIdealBankElement} */
   get stripeElement() {
     return StripeIDealPayment.stripeElement;
   }
 
+  /** @param {StripeIdealBankElement} stripeElement */
   set stripeElement(stripeElement) {
     StripeIDealPayment.stripeElement = stripeElement;
   }
@@ -81,6 +88,10 @@ export default class StripeIDealPayment extends Payment {
     await this.stripe.handleCardAction(intent.client_secret);
   }
 
+  /**
+   * @param {object} cart
+   * @param {import('@stripe/stripe-js').PaymentMethod} paymentMethod
+   */
   async _createIntent(cart, paymentMethod) {
     const { currency, capture_total } = cart;
     const stripeCurrency = (currency || 'EUR').toLowerCase();

--- a/src/payment/klarna/stripe.js
+++ b/src/payment/klarna/stripe.js
@@ -9,6 +9,8 @@ import {
   UnableAuthenticatePaymentMethodError,
 } from '../../utils/errors';
 
+/** @typedef {import('@stripe/stripe-js').Stripe} Stripe */
+
 export default class StripeKlarnaPayment extends Payment {
   constructor(request, options, params, methods) {
     if (!methods.card) {
@@ -27,6 +29,7 @@ export default class StripeKlarnaPayment extends Payment {
     return ['stripe-js'];
   }
 
+  /** @returns {Stripe} */
   get stripe() {
     if (!StripeKlarnaPayment.stripe) {
       if (window.Stripe) {
@@ -41,6 +44,7 @@ export default class StripeKlarnaPayment extends Payment {
     return StripeKlarnaPayment.stripe;
   }
 
+  /** @param {Stripe} stripe */
   set stripe(stripe) {
     StripeKlarnaPayment.stripe = stripe;
   }

--- a/src/payment/payment.js
+++ b/src/payment/payment.js
@@ -82,7 +82,7 @@ export default class Payment {
   /**
    * Returns a cart.
    *
-   * @returns {object}
+   * @returns {Promise<object>}
    */
   async getCart() {
     const cart = await cartApi(this.request, this.options).get();
@@ -98,7 +98,7 @@ export default class Payment {
    * Updates a cart.
    *
    * @param {object} data
-   * @returns {object}
+   * @returns {Promise<object>}
    */
   async updateCart(data) {
     const updateData = cloneDeep(data);
@@ -123,7 +123,7 @@ export default class Payment {
   /**
    * Returns the store settings.
    *
-   * @returns {object}
+   * @returns {Promise<object>}
    */
   async getSettings() {
     return settingsApi(this.request, this.options).get();
@@ -133,7 +133,7 @@ export default class Payment {
    * Creates a payment intent.
    *
    * @param {object} data
-   * @returns {object}
+   * @returns {Promise<object>}
    */
   async createIntent(data) {
     return this._vaultRequest('post', '/intent', data);
@@ -143,7 +143,7 @@ export default class Payment {
    * Updates a payment intent.
    *
    * @param {object} data
-   * @returns {object}
+   * @returns {Promise<object>}
    */
   async updateIntent(data) {
     return this._vaultRequest('put', '/intent', data);
@@ -153,7 +153,7 @@ export default class Payment {
    * Authorizes a payment gateway.
    *
    * @param {object} data
-   * @returns {object}
+   * @returns {Promise<object>}
    */
   async authorizeGateway(data) {
     return this._vaultRequest('post', '/authorization', data);
@@ -216,7 +216,7 @@ export default class Payment {
    * Adjusts cart data.
    *
    * @param {object} cart
-   * @returns {object}
+   * @returns {Promise<object>}
    */
   async _adjustCart(cart) {
     return this._ensureCartSettings(cart).then(toSnake);
@@ -226,7 +226,7 @@ export default class Payment {
    * Sets the store settings to cart.
    *
    * @param {object} cart
-   * @returns {object}
+   * @returns {Promise<object>}
    */
   async _ensureCartSettings(cart) {
     if (cart.settings) {
@@ -244,7 +244,7 @@ export default class Payment {
    * @param {string} method
    * @param {string} url
    * @param {object} data
-   * @returns {object}
+   * @returns {Promise<object>}
    */
   async _vaultRequest(method, url, data) {
     const response = await vaultRequest(method, url, data);

--- a/src/utils/stripe.js
+++ b/src/utils/stripe.js
@@ -1,5 +1,10 @@
 import { get, reduce, toLower, isEmpty } from './index';
 
+/** @typedef {import('@stripe/stripe-js').Stripe} Stripe */
+/** @typedef {import('@stripe/stripe-js').StripeCardElement} StripeCardElement */
+/** @typedef {import('@stripe/stripe-js').StripeCardNumberElement} StripeCardNumberElement */
+/** @typedef {import('@stripe/stripe-js').CreateSourceData} CreateSourceData */
+
 // https://stripe.com/docs/currencies#minimum-and-maximum-charge-amounts
 const MINIMUM_CHARGE_AMOUNT = {
   USD: 0.5,
@@ -71,6 +76,10 @@ function getBillingDetails(cart) {
   return details;
 }
 
+/**
+ * @param {CreateSourceData} source
+ * @param {object} data
+ */
 function setBancontactOwner(source, data) {
   const fillValues = (fieldsMap, data) =>
     reduce(
@@ -100,11 +109,17 @@ function setBancontactOwner(source, data) {
       ? { phone: billingData.phone }
       : account.phone
         ? { phone: account.phone }
-        : {}),
-    ...(!isEmpty(billingAddress) ? { address: billingAddress } : {}),
+        : undefined),
+    ...(!isEmpty(billingAddress) ? { address: billingAddress } : undefined),
   };
 }
 
+/**
+ * @param {string} type
+ * @param {import('@stripe/stripe-js').StripeElements} elements
+ * @param {object} params
+ * @returns {import('@stripe/stripe-js').StripeElement}
+ */
 function createElement(type, elements, params) {
   const elementParams = params[type] || params;
   const elementOptions = elementParams.options || {};
@@ -123,6 +138,11 @@ function createElement(type, elements, params) {
   return element;
 }
 
+/**
+ * @param {Stripe} stripe
+ * @param {StripeCardElement | StripeCardNumberElement} cardElement
+ * @param {object} cart
+ */
 async function createPaymentMethod(stripe, cardElement, cart) {
   const billingDetails = getBillingDetails(cart);
   const { paymentMethod, error } = await stripe.createPaymentMethod({
@@ -141,16 +161,21 @@ async function createPaymentMethod(stripe, cardElement, cart) {
         brand: paymentMethod.card.brand,
         address_check: paymentMethod.card.checks.address_line1_check,
         cvc_check: paymentMethod.card.checks.cvc_check,
-        zip_check: paymentMethod.card.checks.address_zip_check,
+        zip_check: paymentMethod.card.checks.address_postal_code_check,
       };
 }
 
+/**
+ * @param {Stripe} stripe
+ * @param {import('@stripe/stripe-js').StripeIdealBankElement} element
+ * @param {object} cart
+ */
 async function createIDealPaymentMethod(stripe, element, cart) {
   const billingDetails = getBillingDetails(cart);
-  return await stripe.createPaymentMethod({
+  return stripe.createPaymentMethod({
     type: 'ideal',
     ideal: element,
-    ...(billingDetails ? { billing_details: billingDetails } : {}),
+    ...(billingDetails ? { billing_details: billingDetails } : undefined),
   });
 }
 
@@ -173,6 +198,10 @@ function getKlarnaIntentDetails(cart) {
   return details;
 }
 
+/**
+ * @param {object} cart
+ * @returns {import('@stripe/stripe-js').ConfirmKlarnaPaymentData}
+ */
 function getKlarnaConfirmationDetails(cart) {
   const billingDetails = getBillingDetails(cart);
   const returnUrl = `${
@@ -187,7 +216,12 @@ function getKlarnaConfirmationDetails(cart) {
   };
 }
 
+/**
+ * @param {Stripe} stripe
+ * @param {object} cart
+ */
 async function createBancontactSource(stripe, cart) {
+  /** @type {CreateSourceData} */
   const sourceObject = {
     type: 'bancontact',
     amount: Math.round(get(cart, 'grand_total', 0) * 100),
@@ -196,11 +230,17 @@ async function createBancontactSource(stripe, cart) {
       return_url: window.location.href,
     },
   };
+
   setBancontactOwner(sourceObject, cart);
 
-  return await stripe.createSource(sourceObject);
+  return stripe.createSource(sourceObject);
 }
 
+/**
+ * @param {object} cart
+ * @param {object} params
+ * @returns {import('@stripe/stripe-js').PaymentRequestOptions}
+ */
 function getPaymentRequestData(cart, params) {
   const {
     currency,
@@ -263,29 +303,30 @@ function getPaymentRequestData(cart, params) {
   };
 }
 
+const zeroDecimalCurrencies = new Set([
+  'BIF', // Burundian Franc
+  'DJF', // Djiboutian Franc,
+  'JPY', // Japanese Yen
+  'KRW', // South Korean Won
+  'PYG', // Paraguayan Guaraní
+  'VND', // Vietnamese Đồng
+  'XAF', // Central African Cfa Franc
+  'XPF', // Cfp Franc
+  'CLP', // Chilean Peso
+  'GNF', // Guinean Franc
+  'KMF', // Comorian Franc
+  'MGA', // Malagasy Ariary
+  'RWF', // Rwandan Franc
+  'VUV', // Vanuatu Vatu
+  'XOF', // West African Cfa Franc
+]);
+
 function stripeAmountByCurrency(currency, amount) {
-  const zeroDecimalCurrencies = [
-    'BIF', // Burundian Franc
-    'DJF', // Djiboutian Franc,
-    'JPY', // Japanese Yen
-    'KRW', // South Korean Won
-    'PYG', // Paraguayan Guaraní
-    'VND', // Vietnamese Đồng
-    'XAF', // Central African Cfa Franc
-    'XPF', // Cfp Franc
-    'CLP', // Chilean Peso
-    'GNF', // Guinean Franc
-    'KMF', // Comorian Franc
-    'MGA', // Malagasy Ariary
-    'RWF', // Rwandan Franc
-    'VUV', // Vanuatu Vatu
-    'XOF', // West African Cfa Franc
-  ];
-  if (zeroDecimalCurrencies.includes(currency.toUpperCase())) {
+  if (zeroDecimalCurrencies.has(currency.toUpperCase())) {
     return amount;
-  } else {
-    return Math.round(amount * 100);
   }
+
+  return Math.round(amount * 100);
 }
 
 function isStripeChargeableAmount(amount, currency) {

--- a/src/utils/stripe.js
+++ b/src/utils/stripe.js
@@ -159,6 +159,7 @@ async function createPaymentMethod(stripe, cardElement, cart) {
         exp_month: paymentMethod.card.exp_month,
         exp_year: paymentMethod.card.exp_year,
         brand: paymentMethod.card.brand,
+        display_brand: paymentMethod.card.display_brand,
         address_check: paymentMethod.card.checks.address_line1_check,
         cvc_check: paymentMethod.card.checks.cvc_check,
         zip_check: paymentMethod.card.checks.address_postal_code_check,

--- a/src/utils/stripe.test.js
+++ b/src/utils/stripe.test.js
@@ -36,7 +36,7 @@ describe('utils/stripe', () => {
               checks: {
                 address_line1_check: 'address_line1_check',
                 cvc_check: 'cvc_check',
-                address_zip_check: 'address_zip_check',
+                address_postal_code_check: 'address_zip_check',
               },
             },
           },

--- a/src/utils/stripe.test.js
+++ b/src/utils/stripe.test.js
@@ -14,9 +14,10 @@ describe('utils/stripe', () => {
       exp_month: 12,
       exp_year: 99,
       brand: 'Visa',
+      display_brand: 'cartes_bancaires',
       address_check: 'address_line1_check',
       cvc_check: 'cvc_check',
-      zip_check: 'address_zip_check',
+      zip_check: 'address_postal_code_check',
     };
 
     const stripe = {
@@ -33,10 +34,11 @@ describe('utils/stripe', () => {
               exp_month: 12,
               exp_year: 99,
               brand: 'Visa',
+              display_brand: 'cartes_bancaires',
               checks: {
                 address_line1_check: 'address_line1_check',
                 cvc_check: 'cvc_check',
-                address_postal_code_check: 'address_zip_check',
+                address_postal_code_check: 'address_postal_code_check',
               },
             },
           },
@@ -112,10 +114,11 @@ describe('utils/stripe', () => {
               exp_month: 12,
               exp_year: 99,
               brand: 'Visa',
+              display_brand: 'cartes_bancaires',
               checks: {
                 address_line1_check: 'address_line1_check',
                 cvc_check: 'cvc_check',
-                address_zip_check: 'address_zip_check',
+                address_postal_code_check: 'address_postal_code_check',
               },
             },
           },
@@ -153,10 +156,11 @@ describe('utils/stripe', () => {
           exp_month: 12,
           exp_year: 99,
           brand: 'Visa',
+          display_brand: 'cartes_bancaires',
           checks: {
             address_line1_check: 'address_line1_check',
             cvc_check: 'cvc_check',
-            address_zip_check: 'address_zip_check',
+            address_postal_code_check: 'address_postal_code_check',
           },
         },
       });

--- a/test/page/containers/payment/stripe.js
+++ b/test/page/containers/payment/stripe.js
@@ -137,12 +137,14 @@ class Stripe extends React.Component {
           <CardContent>
             <FormControl>
               <FormLabel>Type</FormLabel>
+
               <RadioGroup defaultValue="card" row onChange={this.onChangeType}>
                 <FormControlLabel
                   value="card"
                   control={<Radio />}
                   label="Card"
                 />
+
                 <FormControlLabel
                   value="separate"
                   control={<Radio />}
@@ -150,22 +152,27 @@ class Stripe extends React.Component {
                 />
               </RadioGroup>
             </FormControl>
+
             <FormControl>
               <FormLabel>Font</FormLabel>
+
               <RadioGroup
-                defaultValue="default"
                 row
-                onChange={this.onChangeFont}>
+                defaultValue="default"
+                onChange={this.onChangeFont}
+              >
                 <FormControlLabel
                   value="default"
                   control={<Radio />}
                   label="Default"
                 />
+
                 <FormControlLabel
                   value="audiowide"
                   control={<Radio />}
                   label="Audiowide"
                 />
+
                 <FormControlLabel
                   value="festive"
                   control={<Radio />}
@@ -173,6 +180,7 @@ class Stripe extends React.Component {
                 />
               </RadioGroup>
             </FormControl>
+
             {type === 'card' ? (
               <div id="card-element" className={classes.cardInput} />
             ) : (
@@ -182,6 +190,7 @@ class Stripe extends React.Component {
                 <div id="cardCvc-element" className={classes.cardInput} />
               </Fragment>
             )}
+
             <div className={classes.submitContainer}>
               <Button
                 id="stripe-submit-button"
@@ -189,16 +198,19 @@ class Stripe extends React.Component {
                 color="primary"
                 size="small"
                 classes={{ root: classes.button }}
-                onClick={this.onClickTokenize}>
+                onClick={this.onClickTokenize}
+              >
                 Tokenize
               </Button>
+
               <Button
                 variant="contained"
                 color="secondary"
                 size="small"
                 disabled={!tokenized}
                 classes={{ root: classes.button }}
-                onClick={onOrderSubmit}>
+                onClick={onOrderSubmit}
+              >
                 Submit
               </Button>
             </div>

--- a/test/page/webpack.config.cjs
+++ b/test/page/webpack.config.cjs
@@ -33,6 +33,8 @@ module.exports = {
   },
   devServer: {
     historyApiFallback: true,
+    allowedHosts: ['.swell.test', 'localhost'],
+    host: process.env.DEV_SERVER_HOST,
   },
   mode: 'development',
   plugins: [

--- a/types/card/snake.d.ts
+++ b/types/card/snake.d.ts
@@ -27,6 +27,7 @@ interface CardSnake extends BaseModel {
   address_check?: 'unchecked' | 'pass' | 'fail';
   billing?: Billing;
   brand?: string;
+  display_brand?: string;
   cvc_check?: 'unchecked' | 'pass' | 'fail';
   exp_month?: number;
   exp_year?: number;

--- a/types/payment/snake.d.ts
+++ b/types/payment/snake.d.ts
@@ -56,17 +56,22 @@ interface InputPaymentElementBaseSnake {
 }
 
 interface InputPaymentElementCardSnake extends InputPaymentElementBaseSnake {
-  options?: any; // https://stripe.com/docs/js/elements_object/create_element?type=card
+  /** @see {@link https://docs.stripe.com/js/elements_object/create_element?type=card#elements_create-options} */
+  options?: object;
   separate_elements?: boolean;
   card_number?: {
-    elementId?: string; // default: #card-element
+    /** @default "#card-element" */
+    elementId?: string;
+    /** @see {@link https://docs.stripe.com/js/elements_object/create_element?type=cardNumber#elements_create-options} */
     options?: object;
   };
   card_expiry?: {
-    elementId?: string; // default: #cardExpiry-element
+    /** @default "#cardExpiry-element" */
+    elementId?: string;
   };
   card_cvc?: {
-    elementId?: string; // default: #cardCvc-element
+    /** @default #cardCvc-element */
+    elementId?: string;
   };
 }
 
@@ -77,7 +82,8 @@ interface InputPaymentElementIdealSnake extends InputPaymentElementBaseSnake {
 }
 
 interface InputPaymentElementPaypalSnake extends InputPaymentElementBaseSnake {
-  style?: any; // https://developer.paypal.com/docs/checkout/integration-features/customize-button/
+  /** @see {@link https://developer.paypal.com/docs/checkout/integration-features/customize-button} */
+  style?: any;
 }
 
 interface InputPaymentElementAppleSnake extends InputPaymentElementBaseSnake {


### PR DESCRIPTION
Fixed getting `zip_check` after creating a payment method in `stripe`.

Added `Stripe` types to function arguments and return values.

It was investigated that we should not fix the behavior in `swell-js` to comply with co-badged cards:
https://docs.stripe.com/co-badged-cards-compliance?type=custom-integration

These requirements apply to a specific list of countries. Therefore, users must determine for themselves what options they should pass for `stripe` elements.