### PR TITLE
Add typing for page limit

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -112,6 +112,7 @@ export interface ResultsResponse<T> {
   page_count?: number;
   pageCount?: number;
   results: T[];
+  limit: number;
 }
 
 export interface Tax {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -102,6 +102,7 @@ export interface InitOptions {
 
 export interface ResultsResponse<T> {
   count: number;
+  limit: number;
   page: number;
   pages?: {
     [index: number]: {
@@ -112,7 +113,6 @@ export interface ResultsResponse<T> {
   page_count?: number;
   pageCount?: number;
   results: T[];
-  limit: number;
 }
 
 export interface Tax {


### PR DESCRIPTION
Add type for page `limit` to the paginated result set.