### PR TITLE
make it possible to override api request + create multiple client instances

### DIFF
--- a/mocks/payment.js
+++ b/mocks/payment.js
@@ -67,7 +67,9 @@ const mockPayment = {
   }),
 
   resetAsyncPayment(id) {
-    return this.request('put', '/payments', id, { $reset_async_payment: true });
+    return this.api.request('put', '/payments', id, {
+      $reset_async_payment: true,
+    });
   },
 
   onSuccess: jest.fn(),

--- a/package-lock.json
+++ b/package-lock.json
@@ -4235,19 +4235,11 @@
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.2.tgz",
       "integrity": "sha512-uQDwm1wFHmbBbCZCqAlq6Do9LYwByNZHWzXppSnay9SuwJ+VRbjkbLABer54kcPnMSlG6Fdiy2yaFXm/z9Z5gw==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
-      }
-    },
-    "node_modules/@types/eslint-scope": {
-      "version": "3.7.7",
-      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
-      "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
-      "dev": true,
-      "dependencies": {
-        "@types/eslint": "*",
-        "@types/estree": "*"
       }
     },
     "node_modules/@types/estree": {
@@ -5231,9 +5223,9 @@
       "dev": true
     },
     "node_modules/@webassemblyjs/ast": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.6.tgz",
-      "integrity": "sha512-IN1xI7PwOvLPgjcf180gC1bqn3q/QaOCwYUahIOhbYUu8KA/3tw2RT/T0Gidi1l7Hhj5D/INhJxiICObqpMu4Q==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.12.1.tgz",
+      "integrity": "sha512-EKfMUOPRRUTy5UII4qJDGPpqfwjOmZ5jeGFwid9mnoqIFK+e0vqoi1qH56JpmZSzEL53jKnNzScdmftJyG5xWg==",
       "dev": true,
       "dependencies": {
         "@webassemblyjs/helper-numbers": "1.11.6",
@@ -5253,9 +5245,9 @@
       "dev": true
     },
     "node_modules/@webassemblyjs/helper-buffer": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.6.tgz",
-      "integrity": "sha512-z3nFzdcp1mb8nEOFFk8DrYLpHvhKC3grJD2ardfKOzmbmJvEf/tPIqCY+sNcwZIY8ZD7IkB2l7/pqhUhqm7hLA==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.12.1.tgz",
+      "integrity": "sha512-nzJwQw99DNDKr9BVCOZcLuJJUlqkJh+kVzVl6Fmq/tI5ZtEyWT1KZMyOXltXLZJmDtvLCDgwsyrkohEtopTXCw==",
       "dev": true
     },
     "node_modules/@webassemblyjs/helper-numbers": {
@@ -5276,15 +5268,15 @@
       "dev": true
     },
     "node_modules/@webassemblyjs/helper-wasm-section": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.6.tgz",
-      "integrity": "sha512-LPpZbSOwTpEC2cgn4hTydySy1Ke+XEu+ETXuoyvuyezHO3Kjdu90KK95Sh9xTbmjrCsUwvWwCOQQNta37VrS9g==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.12.1.tgz",
+      "integrity": "sha512-Jif4vfB6FJlUlSbgEMHUyk1j234GTNG9dBJ4XJdOySoj518Xj0oGsNi59cUQF4RRMS9ouBUxDDdyBVfPTypa5g==",
       "dev": true,
       "dependencies": {
-        "@webassemblyjs/ast": "1.11.6",
-        "@webassemblyjs/helper-buffer": "1.11.6",
+        "@webassemblyjs/ast": "1.12.1",
+        "@webassemblyjs/helper-buffer": "1.12.1",
         "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
-        "@webassemblyjs/wasm-gen": "1.11.6"
+        "@webassemblyjs/wasm-gen": "1.12.1"
       }
     },
     "node_modules/@webassemblyjs/ieee754": {
@@ -5312,28 +5304,28 @@
       "dev": true
     },
     "node_modules/@webassemblyjs/wasm-edit": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.6.tgz",
-      "integrity": "sha512-Ybn2I6fnfIGuCR+Faaz7YcvtBKxvoLV3Lebn1tM4o/IAJzmi9AWYIPWpyBfU8cC+JxAO57bk4+zdsTjJR+VTOw==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.12.1.tgz",
+      "integrity": "sha512-1DuwbVvADvS5mGnXbE+c9NfA8QRcZ6iKquqjjmR10k6o+zzsRVesil54DKexiowcFCPdr/Q0qaMgB01+SQ1u6g==",
       "dev": true,
       "dependencies": {
-        "@webassemblyjs/ast": "1.11.6",
-        "@webassemblyjs/helper-buffer": "1.11.6",
+        "@webassemblyjs/ast": "1.12.1",
+        "@webassemblyjs/helper-buffer": "1.12.1",
         "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
-        "@webassemblyjs/helper-wasm-section": "1.11.6",
-        "@webassemblyjs/wasm-gen": "1.11.6",
-        "@webassemblyjs/wasm-opt": "1.11.6",
-        "@webassemblyjs/wasm-parser": "1.11.6",
-        "@webassemblyjs/wast-printer": "1.11.6"
+        "@webassemblyjs/helper-wasm-section": "1.12.1",
+        "@webassemblyjs/wasm-gen": "1.12.1",
+        "@webassemblyjs/wasm-opt": "1.12.1",
+        "@webassemblyjs/wasm-parser": "1.12.1",
+        "@webassemblyjs/wast-printer": "1.12.1"
       }
     },
     "node_modules/@webassemblyjs/wasm-gen": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.6.tgz",
-      "integrity": "sha512-3XOqkZP/y6B4F0PBAXvI1/bky7GryoogUtfwExeP/v7Nzwo1QLcq5oQmpKlftZLbT+ERUOAZVQjuNVak6UXjPA==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.12.1.tgz",
+      "integrity": "sha512-TDq4Ojh9fcohAw6OIMXqiIcTq5KUXTGRkVxbSo1hQnSy6lAM5GSdfwWeSxpAo0YzgsgF182E/U0mDNhuA0tW7w==",
       "dev": true,
       "dependencies": {
-        "@webassemblyjs/ast": "1.11.6",
+        "@webassemblyjs/ast": "1.12.1",
         "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
         "@webassemblyjs/ieee754": "1.11.6",
         "@webassemblyjs/leb128": "1.11.6",
@@ -5341,24 +5333,24 @@
       }
     },
     "node_modules/@webassemblyjs/wasm-opt": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.6.tgz",
-      "integrity": "sha512-cOrKuLRE7PCe6AsOVl7WasYf3wbSo4CeOk6PkrjS7g57MFfVUF9u6ysQBBODX0LdgSvQqRiGz3CXvIDKcPNy4g==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.12.1.tgz",
+      "integrity": "sha512-Jg99j/2gG2iaz3hijw857AVYekZe2SAskcqlWIZXjji5WStnOpVoat3gQfT/Q5tb2djnCjBtMocY/Su1GfxPBg==",
       "dev": true,
       "dependencies": {
-        "@webassemblyjs/ast": "1.11.6",
-        "@webassemblyjs/helper-buffer": "1.11.6",
-        "@webassemblyjs/wasm-gen": "1.11.6",
-        "@webassemblyjs/wasm-parser": "1.11.6"
+        "@webassemblyjs/ast": "1.12.1",
+        "@webassemblyjs/helper-buffer": "1.12.1",
+        "@webassemblyjs/wasm-gen": "1.12.1",
+        "@webassemblyjs/wasm-parser": "1.12.1"
       }
     },
     "node_modules/@webassemblyjs/wasm-parser": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.6.tgz",
-      "integrity": "sha512-6ZwPeGzMJM3Dqp3hCsLgESxBGtT/OeCvCZ4TA1JUPYgmhAx38tTPR9JaKy0S5H3evQpO/h2uWs2j6Yc/fjkpTQ==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.12.1.tgz",
+      "integrity": "sha512-xikIi7c2FHXysxXe3COrVUPSheuBtpcfhbpFj4gmu7KRLYOzANztwUU0IbsqvMqzuNK2+glRGWCEqZo1WCLyAQ==",
       "dev": true,
       "dependencies": {
-        "@webassemblyjs/ast": "1.11.6",
+        "@webassemblyjs/ast": "1.12.1",
         "@webassemblyjs/helper-api-error": "1.11.6",
         "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
         "@webassemblyjs/ieee754": "1.11.6",
@@ -5367,12 +5359,12 @@
       }
     },
     "node_modules/@webassemblyjs/wast-printer": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.6.tgz",
-      "integrity": "sha512-JM7AhRcE+yW2GWYaKeHL5vt4xqee5N2WcezptmgyhNS+ScggqcT1OtXykhAb13Sn5Yas0j2uv9tHgrjwvzAP4A==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.12.1.tgz",
+      "integrity": "sha512-+X4WAlOisVWQMikjbcvY2e0rwPsKQ9F688lksZhBcPycBBuii3O7m8FACbDMWDojpAqvjIncrG8J0XHKyQfVeA==",
       "dev": true,
       "dependencies": {
-        "@webassemblyjs/ast": "1.11.6",
+        "@webassemblyjs/ast": "1.12.1",
         "@xtuc/long": "4.2.2"
       }
     },
@@ -5463,10 +5455,10 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/acorn-import-assertions": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
-      "integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
+    "node_modules/acorn-import-attributes": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
       "dev": true,
       "peerDependencies": {
         "acorn": "^8"
@@ -6174,9 +6166,9 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
-      "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
+      "version": "1.20.3",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
+      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
       "dev": true,
       "dependencies": {
         "bytes": "3.1.2",
@@ -6187,7 +6179,7 @@
         "http-errors": "2.0.0",
         "iconv-lite": "0.4.24",
         "on-finished": "2.4.1",
-        "qs": "6.11.0",
+        "qs": "6.13.0",
         "raw-body": "2.5.2",
         "type-is": "~1.6.18",
         "unpipe": "1.0.0"
@@ -6213,21 +6205,6 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/body-parser/node_modules/qs": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
-      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
-      "dev": true,
-      "dependencies": {
-        "side-channel": "^1.0.4"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/bonjour-service": {
@@ -7658,9 +7635,9 @@
       "dev": true
     },
     "node_modules/encodeurl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
       "dev": true,
       "engines": {
         "node": ">= 0.8"
@@ -7690,9 +7667,9 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.15.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.15.0.tgz",
-      "integrity": "sha512-LXYT42KJ7lpIKECr2mAXIaMldcNCh/7E0KBKOu4KSfkHmP+mZmSs+8V5gBAqisWBy0OO4W5Oyys0GO1Y8KtdKg==",
+      "version": "5.17.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.17.1.tgz",
+      "integrity": "sha512-LMHl3dXhTcfv8gM4kEzIUeTQ+7fpdA0l2tUf34BddXPkz2A5xJ5L/Pchd5BL6rdccM9QGvu0sWZzK1Z1t4wwyg==",
       "dev": true,
       "dependencies": {
         "graceful-fs": "^4.2.4",
@@ -8899,37 +8876,37 @@
       "dev": true
     },
     "node_modules/express": {
-      "version": "4.19.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.19.2.tgz",
-      "integrity": "sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==",
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.0.tgz",
+      "integrity": "sha512-VqcNGcj/Id5ZT1LZ/cfihi3ttTn+NJmkli2eZADigjq29qTlWi/hAQ43t/VLPq8+UX06FCEx3ByOYet6ZFblng==",
       "dev": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.2",
+        "body-parser": "1.20.3",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
         "cookie": "0.6.0",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
-        "encodeurl": "~1.0.2",
+        "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
-        "finalhandler": "1.2.0",
+        "finalhandler": "1.3.1",
         "fresh": "0.5.2",
         "http-errors": "2.0.0",
-        "merge-descriptors": "1.0.1",
+        "merge-descriptors": "1.0.3",
         "methods": "~1.1.2",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.7",
+        "path-to-regexp": "0.1.10",
         "proxy-addr": "~2.0.7",
-        "qs": "6.11.0",
+        "qs": "6.13.0",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
-        "send": "0.18.0",
-        "serve-static": "1.15.0",
+        "send": "0.19.0",
+        "serve-static": "1.16.2",
         "setprototypeof": "1.2.0",
         "statuses": "2.0.1",
         "type-is": "~1.6.18",
@@ -8956,25 +8933,10 @@
       }
     },
     "node_modules/express/node_modules/path-to-regexp": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
+      "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==",
       "dev": true
-    },
-    "node_modules/express/node_modules/qs": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
-      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
-      "dev": true,
-      "dependencies": {
-        "side-channel": "^1.0.4"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/express/node_modules/safe-buffer": {
       "version": "5.2.1",
@@ -9136,13 +9098,13 @@
       }
     },
     "node_modules/finalhandler": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
-      "integrity": "sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
+      "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
       "dev": true,
       "dependencies": {
         "debug": "2.6.9",
-        "encodeurl": "~1.0.2",
+        "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
@@ -9869,9 +9831,9 @@
       }
     },
     "node_modules/graceful-fs": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true
     },
     "node_modules/graphemer": {
@@ -13808,10 +13770,13 @@
       }
     },
     "node_modules/merge-descriptors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
-      "dev": true
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -15550,9 +15515,9 @@
       ]
     },
     "node_modules/qs": {
-      "version": "6.12.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.12.1.tgz",
-      "integrity": "sha512-zWmv4RSuB9r2mYQw3zxQuHWeU+42aKi1wWig/j4ele4ygELZ7PEO6MM7rim9oAQH2A5MWfsAVf/jPvTPgCbvUQ==",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
       "dependencies": {
         "side-channel": "^1.0.6"
       },
@@ -16651,9 +16616,9 @@
       }
     },
     "node_modules/send": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
-      "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
+      "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
       "dev": true,
       "dependencies": {
         "debug": "2.6.9",
@@ -16678,6 +16643,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/send/node_modules/encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
       "dev": true,
       "engines": {
         "node": ">= 0.8"
@@ -16753,15 +16727,15 @@
       "dev": true
     },
     "node_modules/serve-static": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
-      "integrity": "sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==",
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
+      "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
       "dev": true,
       "dependencies": {
-        "encodeurl": "~1.0.2",
+        "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "parseurl": "~1.3.3",
-        "send": "0.18.0"
+        "send": "0.19.0"
       },
       "engines": {
         "node": ">= 0.8.0"
@@ -18322,9 +18296,9 @@
       }
     },
     "node_modules/watchpack": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
-      "integrity": "sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.2.tgz",
+      "integrity": "sha512-TnbFSbcOCcDgjZ4piURLCbJ3nJhznVh9kw6F6iokjiFPl8ONxe9A6nMDVXDiNbrSfLILs6vB07F7wLBrwPYzJw==",
       "dev": true,
       "dependencies": {
         "glob-to-regexp": "^0.4.1",
@@ -18344,34 +18318,33 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.89.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
-      "integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
+      "version": "5.94.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.94.0.tgz",
+      "integrity": "sha512-KcsGn50VT+06JH/iunZJedYGUJS5FGjow8wb9c0v5n1Om8O1g4L6LjtfxwlXIATopoQu+vOXXa7gYisWxCoPyg==",
       "dev": true,
       "dependencies": {
-        "@types/eslint-scope": "^3.7.3",
-        "@types/estree": "^1.0.0",
-        "@webassemblyjs/ast": "^1.11.5",
-        "@webassemblyjs/wasm-edit": "^1.11.5",
-        "@webassemblyjs/wasm-parser": "^1.11.5",
+        "@types/estree": "^1.0.5",
+        "@webassemblyjs/ast": "^1.12.1",
+        "@webassemblyjs/wasm-edit": "^1.12.1",
+        "@webassemblyjs/wasm-parser": "^1.12.1",
         "acorn": "^8.7.1",
-        "acorn-import-assertions": "^1.9.0",
-        "browserslist": "^4.14.5",
+        "acorn-import-attributes": "^1.9.5",
+        "browserslist": "^4.21.10",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.15.0",
+        "enhanced-resolve": "^5.17.1",
         "es-module-lexer": "^1.2.1",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
         "glob-to-regexp": "^0.4.1",
-        "graceful-fs": "^4.2.9",
+        "graceful-fs": "^4.2.11",
         "json-parse-even-better-errors": "^2.3.1",
         "loader-runner": "^4.2.0",
         "mime-types": "^2.1.27",
         "neo-async": "^2.6.2",
         "schema-utils": "^3.2.0",
         "tapable": "^2.1.1",
-        "terser-webpack-plugin": "^5.3.7",
-        "watchpack": "^2.4.0",
+        "terser-webpack-plugin": "^5.3.10",
+        "watchpack": "^2.4.1",
         "webpack-sources": "^3.2.3"
       },
       "bin": {
@@ -21921,19 +21894,11 @@
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.2.tgz",
       "integrity": "sha512-uQDwm1wFHmbBbCZCqAlq6Do9LYwByNZHWzXppSnay9SuwJ+VRbjkbLABer54kcPnMSlG6Fdiy2yaFXm/z9Z5gw==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "requires": {
         "@types/estree": "*",
         "@types/json-schema": "*"
-      }
-    },
-    "@types/eslint-scope": {
-      "version": "3.7.7",
-      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
-      "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
-      "dev": true,
-      "requires": {
-        "@types/eslint": "*",
-        "@types/estree": "*"
       }
     },
     "@types/estree": {
@@ -22641,9 +22606,9 @@
       "dev": true
     },
     "@webassemblyjs/ast": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.6.tgz",
-      "integrity": "sha512-IN1xI7PwOvLPgjcf180gC1bqn3q/QaOCwYUahIOhbYUu8KA/3tw2RT/T0Gidi1l7Hhj5D/INhJxiICObqpMu4Q==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.12.1.tgz",
+      "integrity": "sha512-EKfMUOPRRUTy5UII4qJDGPpqfwjOmZ5jeGFwid9mnoqIFK+e0vqoi1qH56JpmZSzEL53jKnNzScdmftJyG5xWg==",
       "dev": true,
       "requires": {
         "@webassemblyjs/helper-numbers": "1.11.6",
@@ -22663,9 +22628,9 @@
       "dev": true
     },
     "@webassemblyjs/helper-buffer": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.6.tgz",
-      "integrity": "sha512-z3nFzdcp1mb8nEOFFk8DrYLpHvhKC3grJD2ardfKOzmbmJvEf/tPIqCY+sNcwZIY8ZD7IkB2l7/pqhUhqm7hLA==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.12.1.tgz",
+      "integrity": "sha512-nzJwQw99DNDKr9BVCOZcLuJJUlqkJh+kVzVl6Fmq/tI5ZtEyWT1KZMyOXltXLZJmDtvLCDgwsyrkohEtopTXCw==",
       "dev": true
     },
     "@webassemblyjs/helper-numbers": {
@@ -22686,15 +22651,15 @@
       "dev": true
     },
     "@webassemblyjs/helper-wasm-section": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.6.tgz",
-      "integrity": "sha512-LPpZbSOwTpEC2cgn4hTydySy1Ke+XEu+ETXuoyvuyezHO3Kjdu90KK95Sh9xTbmjrCsUwvWwCOQQNta37VrS9g==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.12.1.tgz",
+      "integrity": "sha512-Jif4vfB6FJlUlSbgEMHUyk1j234GTNG9dBJ4XJdOySoj518Xj0oGsNi59cUQF4RRMS9ouBUxDDdyBVfPTypa5g==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.11.6",
-        "@webassemblyjs/helper-buffer": "1.11.6",
+        "@webassemblyjs/ast": "1.12.1",
+        "@webassemblyjs/helper-buffer": "1.12.1",
         "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
-        "@webassemblyjs/wasm-gen": "1.11.6"
+        "@webassemblyjs/wasm-gen": "1.12.1"
       }
     },
     "@webassemblyjs/ieee754": {
@@ -22722,28 +22687,28 @@
       "dev": true
     },
     "@webassemblyjs/wasm-edit": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.6.tgz",
-      "integrity": "sha512-Ybn2I6fnfIGuCR+Faaz7YcvtBKxvoLV3Lebn1tM4o/IAJzmi9AWYIPWpyBfU8cC+JxAO57bk4+zdsTjJR+VTOw==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.12.1.tgz",
+      "integrity": "sha512-1DuwbVvADvS5mGnXbE+c9NfA8QRcZ6iKquqjjmR10k6o+zzsRVesil54DKexiowcFCPdr/Q0qaMgB01+SQ1u6g==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.11.6",
-        "@webassemblyjs/helper-buffer": "1.11.6",
+        "@webassemblyjs/ast": "1.12.1",
+        "@webassemblyjs/helper-buffer": "1.12.1",
         "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
-        "@webassemblyjs/helper-wasm-section": "1.11.6",
-        "@webassemblyjs/wasm-gen": "1.11.6",
-        "@webassemblyjs/wasm-opt": "1.11.6",
-        "@webassemblyjs/wasm-parser": "1.11.6",
-        "@webassemblyjs/wast-printer": "1.11.6"
+        "@webassemblyjs/helper-wasm-section": "1.12.1",
+        "@webassemblyjs/wasm-gen": "1.12.1",
+        "@webassemblyjs/wasm-opt": "1.12.1",
+        "@webassemblyjs/wasm-parser": "1.12.1",
+        "@webassemblyjs/wast-printer": "1.12.1"
       }
     },
     "@webassemblyjs/wasm-gen": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.6.tgz",
-      "integrity": "sha512-3XOqkZP/y6B4F0PBAXvI1/bky7GryoogUtfwExeP/v7Nzwo1QLcq5oQmpKlftZLbT+ERUOAZVQjuNVak6UXjPA==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.12.1.tgz",
+      "integrity": "sha512-TDq4Ojh9fcohAw6OIMXqiIcTq5KUXTGRkVxbSo1hQnSy6lAM5GSdfwWeSxpAo0YzgsgF182E/U0mDNhuA0tW7w==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.11.6",
+        "@webassemblyjs/ast": "1.12.1",
         "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
         "@webassemblyjs/ieee754": "1.11.6",
         "@webassemblyjs/leb128": "1.11.6",
@@ -22751,24 +22716,24 @@
       }
     },
     "@webassemblyjs/wasm-opt": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.6.tgz",
-      "integrity": "sha512-cOrKuLRE7PCe6AsOVl7WasYf3wbSo4CeOk6PkrjS7g57MFfVUF9u6ysQBBODX0LdgSvQqRiGz3CXvIDKcPNy4g==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.12.1.tgz",
+      "integrity": "sha512-Jg99j/2gG2iaz3hijw857AVYekZe2SAskcqlWIZXjji5WStnOpVoat3gQfT/Q5tb2djnCjBtMocY/Su1GfxPBg==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.11.6",
-        "@webassemblyjs/helper-buffer": "1.11.6",
-        "@webassemblyjs/wasm-gen": "1.11.6",
-        "@webassemblyjs/wasm-parser": "1.11.6"
+        "@webassemblyjs/ast": "1.12.1",
+        "@webassemblyjs/helper-buffer": "1.12.1",
+        "@webassemblyjs/wasm-gen": "1.12.1",
+        "@webassemblyjs/wasm-parser": "1.12.1"
       }
     },
     "@webassemblyjs/wasm-parser": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.6.tgz",
-      "integrity": "sha512-6ZwPeGzMJM3Dqp3hCsLgESxBGtT/OeCvCZ4TA1JUPYgmhAx38tTPR9JaKy0S5H3evQpO/h2uWs2j6Yc/fjkpTQ==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.12.1.tgz",
+      "integrity": "sha512-xikIi7c2FHXysxXe3COrVUPSheuBtpcfhbpFj4gmu7KRLYOzANztwUU0IbsqvMqzuNK2+glRGWCEqZo1WCLyAQ==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.11.6",
+        "@webassemblyjs/ast": "1.12.1",
         "@webassemblyjs/helper-api-error": "1.11.6",
         "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
         "@webassemblyjs/ieee754": "1.11.6",
@@ -22777,12 +22742,12 @@
       }
     },
     "@webassemblyjs/wast-printer": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.6.tgz",
-      "integrity": "sha512-JM7AhRcE+yW2GWYaKeHL5vt4xqee5N2WcezptmgyhNS+ScggqcT1OtXykhAb13Sn5Yas0j2uv9tHgrjwvzAP4A==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.12.1.tgz",
+      "integrity": "sha512-+X4WAlOisVWQMikjbcvY2e0rwPsKQ9F688lksZhBcPycBBuii3O7m8FACbDMWDojpAqvjIncrG8J0XHKyQfVeA==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.11.6",
+        "@webassemblyjs/ast": "1.12.1",
         "@xtuc/long": "4.2.2"
       }
     },
@@ -22841,10 +22806,10 @@
       "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
       "dev": true
     },
-    "acorn-import-assertions": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
-      "integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
+    "acorn-import-attributes": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
       "dev": true,
       "requires": {}
     },
@@ -23368,9 +23333,9 @@
       "dev": true
     },
     "body-parser": {
-      "version": "1.20.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
-      "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
+      "version": "1.20.3",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
+      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
       "dev": true,
       "requires": {
         "bytes": "3.1.2",
@@ -23381,7 +23346,7 @@
         "http-errors": "2.0.0",
         "iconv-lite": "0.4.24",
         "on-finished": "2.4.1",
-        "qs": "6.11.0",
+        "qs": "6.13.0",
         "raw-body": "2.5.2",
         "type-is": "~1.6.18",
         "unpipe": "1.0.0"
@@ -23398,15 +23363,6 @@
           "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
           "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
           "dev": true
-        },
-        "qs": {
-          "version": "6.11.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
-          "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
-          "dev": true,
-          "requires": {
-            "side-channel": "^1.0.4"
-          }
         }
       }
     },
@@ -24457,9 +24413,9 @@
       "dev": true
     },
     "encodeurl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
       "dev": true
     },
     "encoding": {
@@ -24485,9 +24441,9 @@
       }
     },
     "enhanced-resolve": {
-      "version": "5.15.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.15.0.tgz",
-      "integrity": "sha512-LXYT42KJ7lpIKECr2mAXIaMldcNCh/7E0KBKOu4KSfkHmP+mZmSs+8V5gBAqisWBy0OO4W5Oyys0GO1Y8KtdKg==",
+      "version": "5.17.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.17.1.tgz",
+      "integrity": "sha512-LMHl3dXhTcfv8gM4kEzIUeTQ+7fpdA0l2tUf34BddXPkz2A5xJ5L/Pchd5BL6rdccM9QGvu0sWZzK1Z1t4wwyg==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.2.4",
@@ -25376,37 +25332,37 @@
       "dev": true
     },
     "express": {
-      "version": "4.19.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.19.2.tgz",
-      "integrity": "sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==",
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.0.tgz",
+      "integrity": "sha512-VqcNGcj/Id5ZT1LZ/cfihi3ttTn+NJmkli2eZADigjq29qTlWi/hAQ43t/VLPq8+UX06FCEx3ByOYet6ZFblng==",
       "dev": true,
       "requires": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.2",
+        "body-parser": "1.20.3",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
         "cookie": "0.6.0",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
-        "encodeurl": "~1.0.2",
+        "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
-        "finalhandler": "1.2.0",
+        "finalhandler": "1.3.1",
         "fresh": "0.5.2",
         "http-errors": "2.0.0",
-        "merge-descriptors": "1.0.1",
+        "merge-descriptors": "1.0.3",
         "methods": "~1.1.2",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.7",
+        "path-to-regexp": "0.1.10",
         "proxy-addr": "~2.0.7",
-        "qs": "6.11.0",
+        "qs": "6.13.0",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
-        "send": "0.18.0",
-        "serve-static": "1.15.0",
+        "send": "0.19.0",
+        "serve-static": "1.16.2",
         "setprototypeof": "1.2.0",
         "statuses": "2.0.1",
         "type-is": "~1.6.18",
@@ -25427,19 +25383,10 @@
           "dev": true
         },
         "path-to-regexp": {
-          "version": "0.1.7",
-          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-          "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
+          "version": "0.1.10",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
+          "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==",
           "dev": true
-        },
-        "qs": {
-          "version": "6.11.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
-          "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
-          "dev": true,
-          "requires": {
-            "side-channel": "^1.0.4"
-          }
         },
         "safe-buffer": {
           "version": "5.2.1",
@@ -25567,13 +25514,13 @@
       }
     },
     "finalhandler": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
-      "integrity": "sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
+      "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
       "dev": true,
       "requires": {
         "debug": "2.6.9",
-        "encodeurl": "~1.0.2",
+        "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
@@ -26083,9 +26030,9 @@
       }
     },
     "graceful-fs": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true
     },
     "graphemer": {
@@ -29025,9 +28972,9 @@
       }
     },
     "merge-descriptors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
       "dev": true
     },
     "merge-stream": {
@@ -30300,9 +30247,9 @@
       "dev": true
     },
     "qs": {
-      "version": "6.12.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.12.1.tgz",
-      "integrity": "sha512-zWmv4RSuB9r2mYQw3zxQuHWeU+42aKi1wWig/j4ele4ygELZ7PEO6MM7rim9oAQH2A5MWfsAVf/jPvTPgCbvUQ==",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
       "requires": {
         "side-channel": "^1.0.6"
       }
@@ -31107,9 +31054,9 @@
       "dev": true
     },
     "send": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
-      "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
+      "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
       "dev": true,
       "requires": {
         "debug": "2.6.9",
@@ -31131,6 +31078,12 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
           "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+          "dev": true
+        },
+        "encodeurl": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+          "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
           "dev": true
         },
         "ms": {
@@ -31198,15 +31151,15 @@
       }
     },
     "serve-static": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
-      "integrity": "sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==",
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
+      "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
       "dev": true,
       "requires": {
-        "encodeurl": "~1.0.2",
+        "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "parseurl": "~1.3.3",
-        "send": "0.18.0"
+        "send": "0.19.0"
       }
     },
     "set-blocking": {
@@ -32382,9 +32335,9 @@
       }
     },
     "watchpack": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
-      "integrity": "sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.2.tgz",
+      "integrity": "sha512-TnbFSbcOCcDgjZ4piURLCbJ3nJhznVh9kw6F6iokjiFPl8ONxe9A6nMDVXDiNbrSfLILs6vB07F7wLBrwPYzJw==",
       "dev": true,
       "requires": {
         "glob-to-regexp": "^0.4.1",
@@ -32401,34 +32354,33 @@
       }
     },
     "webpack": {
-      "version": "5.89.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
-      "integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
+      "version": "5.94.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.94.0.tgz",
+      "integrity": "sha512-KcsGn50VT+06JH/iunZJedYGUJS5FGjow8wb9c0v5n1Om8O1g4L6LjtfxwlXIATopoQu+vOXXa7gYisWxCoPyg==",
       "dev": true,
       "requires": {
-        "@types/eslint-scope": "^3.7.3",
-        "@types/estree": "^1.0.0",
-        "@webassemblyjs/ast": "^1.11.5",
-        "@webassemblyjs/wasm-edit": "^1.11.5",
-        "@webassemblyjs/wasm-parser": "^1.11.5",
+        "@types/estree": "^1.0.5",
+        "@webassemblyjs/ast": "^1.12.1",
+        "@webassemblyjs/wasm-edit": "^1.12.1",
+        "@webassemblyjs/wasm-parser": "^1.12.1",
         "acorn": "^8.7.1",
-        "acorn-import-assertions": "^1.9.0",
-        "browserslist": "^4.14.5",
+        "acorn-import-attributes": "^1.9.5",
+        "browserslist": "^4.21.10",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.15.0",
+        "enhanced-resolve": "^5.17.1",
         "es-module-lexer": "^1.2.1",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
         "glob-to-regexp": "^0.4.1",
-        "graceful-fs": "^4.2.9",
+        "graceful-fs": "^4.2.11",
         "json-parse-even-better-errors": "^2.3.1",
         "loader-runner": "^4.2.0",
         "mime-types": "^2.1.27",
         "neo-async": "^2.6.2",
         "schema-utils": "^3.2.0",
         "tapable": "^2.1.1",
-        "terser-webpack-plugin": "^5.3.7",
-        "watchpack": "^2.4.0",
+        "terser-webpack-plugin": "^5.3.10",
+        "watchpack": "^2.4.1",
         "webpack-sources": "^3.2.3"
       },
       "dependencies": {

--- a/src/account.js
+++ b/src/account.js
@@ -1,9 +1,9 @@
-function methods(request) {
+function methods(api) {
   return {
     state: null,
 
     async requestStateChange(method, url, id, data) {
-      const result = await request(method, url, id, data);
+      const result = await api.request(method, url, id, data);
       if (result && result.errors) {
         return result;
       }
@@ -37,51 +37,51 @@ function methods(request) {
 
     logout() {
       this.state = null;
-      return request('post', '/account/logout');
+      return api.request('post', '/account/logout');
     },
 
     recover(data) {
-      return request('post', '/account/recover', data);
+      return api.request('post', '/account/recover', data);
     },
 
     listAddresses(query) {
-      return request('get', '/account/addresses', query);
+      return api.request('get', '/account/addresses', query);
     },
 
     createAddress(data) {
-      return request('post', '/account/addresses', data);
+      return api.request('post', '/account/addresses', data);
     },
 
     updateAddress(id, data) {
-      return request('put', `/account/addresses/${id}`, data);
+      return api.request('put', `/account/addresses/${id}`, data);
     },
 
     deleteAddress(id) {
-      return request('delete', `/account/addresses/${id}`);
+      return api.request('delete', `/account/addresses/${id}`);
     },
 
     listCards(query) {
-      return request('get', '/account/cards', query);
+      return api.request('get', '/account/cards', query);
     },
 
     createCard(data) {
-      return request('post', '/account/cards', data);
+      return api.request('post', '/account/cards', data);
     },
 
     updateCard(id, data) {
-      return request('put', `/account/cards/${id}`, data);
+      return api.request('put', `/account/cards/${id}`, data);
     },
 
     deleteCard(id) {
-      return request('delete', `/account/cards/${id}`);
+      return api.request('delete', `/account/cards/${id}`);
     },
 
     listOrders(query) {
-      return request('get', '/account/orders', query);
+      return api.request('get', '/account/orders', query);
     },
 
     getOrder(id) {
-      return request('get', `/account/orders/${id}`);
+      return api.request('get', `/account/orders/${id}`);
     },
 
     // Deprecated methods
@@ -90,21 +90,21 @@ function methods(request) {
      * @deprecated use `listAddresses` instead
      */
     getAddresses(query) {
-      return request('get', '/account/addresses', query);
+      return api.request('get', '/account/addresses', query);
     },
 
     /**
      * @deprecated use `listCards` instead
      */
     getCards(query) {
-      return request('get', '/account/cards', query);
+      return api.request('get', '/account/cards', query);
     },
 
     /**
      * @deprecated use `listOrders` instead
      */
     getOrders(query) {
-      return request('get', '/account/orders', query);
+      return api.request('get', '/account/orders', query);
     },
   };
 }

--- a/src/api.js
+++ b/src/api.js
@@ -17,7 +17,14 @@ import currency from './currency';
 import functions from './functions';
 import * as utils from './utils';
 
-function swell(initStore = undefined, initKey, initOpt = {}) {
+/**
+ * Swell API client
+ * @param {string} initStore - Store name
+ * @param {string} initKey - API key
+ * @param {InitOptions} initOptions - Options
+ * @returns {swell} API client
+ */
+function swell(initStore = undefined, initKey, initOptions = {}) {
   const options = {
     store: null,
     key: null,
@@ -224,7 +231,7 @@ function swell(initStore = undefined, initKey, initOpt = {}) {
   }
 
   if (initStore) {
-    api.init(initStore, initKey, initOpt);
+    api.init(initStore, initKey, initOptions);
   }
 
   return api;

--- a/src/api.js
+++ b/src/api.js
@@ -22,7 +22,7 @@ import * as utils from './utils';
  * @param {string} initStore - Store name
  * @param {string} initKey - API key
  * @param {InitOptions} initOptions - Options
- * @returns {swell} API client
+ * @returns {SwellClient} API client
  */
 function swell(initStore = undefined, initKey, initOptions = {}) {
   const options = {

--- a/src/api.js
+++ b/src/api.js
@@ -17,207 +17,221 @@ import currency from './currency';
 import functions from './functions';
 import * as utils from './utils';
 
-const options = {
-  store: null,
-  key: null,
-  url: null,
-  useCamelCase: null,
-  previewContent: null,
-};
-
-const api = {
-  version: '__VERSION__',
-  options,
-  request,
-
-  init(store, key, opt = {}) {
-    options.key = key;
-    options.store = store;
-    options.url = opt.url
-      ? utils.trimEnd(opt.url)
-      : `https://${store}.swell.store`;
-    options.vaultUrl = opt.vaultUrl
-      ? utils.trimEnd(opt.vaultUrl)
-      : `https://vault.schema.io`;
-    options.timeout = (opt.timeout && parseInt(opt.timeout, 10)) || 20000;
-    options.useCamelCase = opt.useCamelCase || false;
-    options.previewContent = opt.previewContent || false;
-    options.session = opt.session;
-    options.locale = opt.locale;
-    options.currency = opt.currency;
-    options.api = api;
-    options.getCookie = opt.getCookie || getCookie;
-    options.setCookie = opt.setCookie || setCookie;
-    options.getCart = opt.getCart;
-    options.updateCart = opt.updateCart;
-    utils.setOptions(options);
-  },
-
-  // Backward compatibility
-  auth(...args) {
-    return this.init(...args);
-  },
-
-  get(url, query) {
-    return request('get', url, query);
-  },
-
-  put(url, data) {
-    return request('put', url, data);
-  },
-
-  post(url, data) {
-    return request('post', url, data);
-  },
-
-  delete(url, data) {
-    return request('delete', url, data);
-  },
-
-  cache,
-
-  card,
-
-  cart: cart(request, options),
-
-  account: account(request, options),
-
-  products: products(request, options),
-
-  categories: categories(request, options),
-
-  attributes: attributes(request, options),
-
-  subscriptions: subscriptions(request, options),
-
-  invoices: invoices(request, options),
-
-  content: content(request, options),
-
-  settings: settings(request, options),
-
-  payment: new Payment(request, options),
-
-  locale: locale(request, options),
-
-  currency: currency(request, options),
-
-  session: session(request, options),
-
-  functions: functions(request, options),
-
-  utils,
-};
-
-async function request(
-  method,
-  url,
-  id = undefined,
-  data = undefined,
-  opt = undefined,
-) {
-  const allOptions = {
-    ...options,
-    ...opt,
+function swell(initStore = undefined, initKey, initOpt = {}) {
+  const options = {
+    store: null,
+    key: null,
+    url: null,
+    useCamelCase: null,
+    previewContent: null,
   };
 
-  const session = allOptions.session || allOptions.getCookie('swell-session');
-  const locale = allOptions.locale || allOptions.getCookie('swell-locale');
-  const currency =
-    allOptions.currency || allOptions.getCookie('swell-currency');
-  const path = allOptions.path || '/api';
+  const api = {};
 
-  const baseUrl = `${allOptions.url}${allOptions.base || ''}${path}`;
-  const reqMethod = String(method).toLowerCase();
+  Object.assign(api, {
+    version: '__VERSION__',
+    options,
+    request,
 
-  let reqUrl = url;
-  let reqData = id;
+    init(store, key, opt = {}) {
+      options.key = key;
+      options.store = store;
+      options.url = opt.url
+        ? utils.trimEnd(opt.url)
+        : `https://${store}.swell.store`;
+      options.vaultUrl = opt.vaultUrl
+        ? utils.trimEnd(opt.vaultUrl)
+        : `https://vault.schema.io`;
+      options.timeout = (opt.timeout && parseInt(opt.timeout, 10)) || 20000;
+      options.useCamelCase = opt.useCamelCase || false;
+      options.previewContent = opt.previewContent || false;
+      options.session = opt.session;
+      options.locale = opt.locale;
+      options.currency = opt.currency;
+      options.api = api;
+      options.getCookie = opt.getCookie || getCookie;
+      options.setCookie = opt.setCookie || setCookie;
+      options.getCart = opt.getCart;
+      options.updateCart = opt.updateCart;
+      utils.setOptions(options);
+    },
 
-  if (data !== undefined || typeof id === 'string') {
-    reqUrl = [utils.trimEnd(url), utils.trimStart(id)].join('/');
-    reqData = data;
-  }
+    // Backward compatibility
+    auth(...args) {
+      return this.init(...args);
+    },
 
-  reqUrl = allOptions.fullUrl || `${baseUrl}/${utils.trimBoth(reqUrl)}`;
-  reqData = allOptions.useCamelCase ? utils.toSnake(reqData) : reqData;
+    get(url, query) {
+      return api.request('get', url, query);
+    },
 
-  let reqBody;
-  if (reqMethod === 'get') {
-    let exQuery;
-    [reqUrl, exQuery] = reqUrl.split('?');
-    const fullQuery = [exQuery, utils.stringifyQuery(reqData)]
-      .join('&')
-      .replace(/^&/, '');
-    reqUrl = `${reqUrl}${fullQuery ? `?${fullQuery}` : ''}`;
-  } else {
-    reqBody = JSON.stringify(reqData);
-  }
+    put(url, data) {
+      return api.request('put', url, data);
+    },
 
-  const reqHeaders = {
-    Accept: 'application/json',
-    'Content-Type': 'application/json',
-    Authorization: `Basic ${utils.base64Encode(String(allOptions.key))}`,
-  };
+    post(url, data) {
+      return api.request('post', url, data);
+    },
 
-  if (session) {
-    reqHeaders['X-Session'] = session;
-  }
+    delete(url, data) {
+      return api.request('delete', url, data);
+    },
 
-  if (locale) {
-    reqHeaders['X-Locale'] = locale;
-  }
+    cache,
 
-  if (currency) {
-    reqHeaders['X-Currency'] = currency;
-  }
+    card,
 
-  const response = await fetch(reqUrl, {
-    method: reqMethod,
-    headers: reqHeaders,
-    body: reqBody,
-    // Credentials and mode are only available in the browser
-    ...(!utils.isServer()
-      ? {
-          credentials: 'include',
-          mode: 'cors',
-        }
-      : undefined),
+    cart: cart(api, options),
+
+    account: account(api, options),
+
+    products: products(api, options),
+
+    categories: categories(api, options),
+
+    attributes: attributes(api, options),
+
+    subscriptions: subscriptions(api, options),
+
+    invoices: invoices(api, options),
+
+    content: content(api, options),
+
+    settings: settings(api, options),
+
+    payment: new Payment(api, options),
+
+    locale: locale(api, options),
+
+    currency: currency(api, options),
+
+    session: session(api, options),
+
+    functions: functions(api, options),
+
+    utils,
   });
 
-  const responseSession = response.headers.get('X-Session');
+  async function request(
+    method,
+    url,
+    id = undefined,
+    data = undefined,
+    opt = undefined,
+  ) {
+    const allOptions = {
+      ...options,
+      ...opt,
+    };
 
-  if (typeof responseSession === 'string' && session !== responseSession) {
-    allOptions.setCookie('swell-session', responseSession);
-  }
+    const session = allOptions.session || allOptions.getCookie('swell-session');
+    const locale = allOptions.locale || allOptions.getCookie('swell-locale');
+    const currency =
+      allOptions.currency || allOptions.getCookie('swell-currency');
+    const path = allOptions.path || '/api';
 
-  // Response could be text, json, or empty
-  let result = null;
-  try {
-    result = await response.text();
+    const baseUrl = `${allOptions.url}${allOptions.base || ''}${path}`;
+    const reqMethod = String(method).toLowerCase();
+
+    let reqUrl = url;
+    let reqData = id;
+
+    if (data !== undefined || typeof id === 'string') {
+      reqUrl = [utils.trimEnd(url), utils.trimStart(id)].join('/');
+      reqData = data;
+    }
+
+    reqUrl = allOptions.fullUrl || `${baseUrl}/${utils.trimBoth(reqUrl)}`;
+    reqData = allOptions.useCamelCase ? utils.toSnake(reqData) : reqData;
+
+    let reqBody;
+    if (reqMethod === 'get') {
+      let exQuery;
+      [reqUrl, exQuery] = reqUrl.split('?');
+      const fullQuery = [exQuery, utils.stringifyQuery(reqData)]
+        .join('&')
+        .replace(/^&/, '');
+      reqUrl = `${reqUrl}${fullQuery ? `?${fullQuery}` : ''}`;
+    } else {
+      reqBody = JSON.stringify(reqData);
+    }
+
+    const reqHeaders = {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+      Authorization: `Basic ${utils.base64Encode(String(allOptions.key))}`,
+    };
+
+    if (session) {
+      reqHeaders['X-Session'] = session;
+    }
+
+    if (locale) {
+      reqHeaders['X-Locale'] = locale;
+    }
+
+    if (currency) {
+      reqHeaders['X-Currency'] = currency;
+    }
+
+    const response = await fetch(reqUrl, {
+      method: reqMethod,
+      headers: reqHeaders,
+      body: reqBody,
+      // Credentials and mode are only available in the browser
+      ...(!utils.isServer()
+        ? {
+            credentials: 'include',
+            mode: 'cors',
+          }
+        : undefined),
+    });
+
+    const responseSession = response.headers.get('X-Session');
+
+    if (typeof responseSession === 'string' && session !== responseSession) {
+      allOptions.setCookie('swell-session', responseSession);
+    }
+
+    // Response could be text, json, or empty
+    let result = null;
     try {
-      result = JSON.parse(result);
+      result = await response.text();
+      try {
+        result = JSON.parse(result);
+      } catch (err) {
+        // noop
+      }
     } catch (err) {
       // noop
     }
-  } catch (err) {
-    // noop
+
+    if (result && result.error) {
+      const err = new Error(result.error.message || result.error);
+      err.status = response.status;
+      err.code = result.error.code;
+      err.param = result.error.param;
+      throw err;
+    } else if (!response.ok) {
+      const err = new Error(
+        'A connection error occurred while making the request',
+      );
+      err.code = 'connection_error';
+      throw err;
+    }
+
+    return allOptions.useCamelCase ? utils.toCamel(result) : result;
   }
 
-  if (result && result.error) {
-    const err = new Error(result.error.message || result.error);
-    err.status = response.status;
-    err.code = result.error.code;
-    err.param = result.error.param;
-    throw err;
-  } else if (!response.ok) {
-    const err = new Error(
-      'A connection error occurred while making the request',
-    );
-    err.code = 'connection_error';
-    throw err;
+  if (initStore) {
+    api.init(initStore, initKey, initOpt);
   }
 
-  return allOptions.useCamelCase ? utils.toCamel(result) : result;
+  return api;
 }
 
-export default api;
+const instance = swell();
+
+instance.create = swell;
+
+export default instance;

--- a/src/attributes.js
+++ b/src/attributes.js
@@ -1,8 +1,8 @@
 import { defaultMethods } from './utils';
 import cache from './cache';
 
-function methods(request) {
-  const { get, list } = defaultMethods(request, '/attributes', ['list', 'get']);
+function methods(api) {
+  const { get, list } = defaultMethods(api, '/attributes', ['list', 'get']);
 
   return {
     get: (id, ...args) => {

--- a/src/cart.js
+++ b/src/cart.js
@@ -1,7 +1,7 @@
 import { cloneDeep } from './utils';
 import { cleanProductOptions } from './products';
 
-function methods(request, options) {
+function methods(api, options) {
   return {
     state: null,
     order: null,
@@ -12,7 +12,7 @@ function methods(request, options) {
 
     async requestStateChange(method, url, id, data) {
       return this.requestStateSync(async () => {
-        const result = await request(method, url, id, data);
+        const result = await api.request(method, url, id, data);
 
         if (result && result.errors) {
           return result;
@@ -169,18 +169,18 @@ function methods(request, options) {
     async getOrder(checkoutId = undefined) {
       let result;
       if (checkoutId) {
-        result = await request('get', '/cart/order', {
+        result = await api.request('get', '/cart/order', {
           checkout_id: checkoutId,
         });
       } else {
-        result = await request('get', '/cart/order');
+        result = await api.request('get', '/cart/order');
       }
       this.order = result;
       return result;
     },
 
     async getSettings() {
-      this.settings = await request('get', '/cart/settings');
+      this.settings = await api.request('get', '/cart/settings');
       return this.settings;
     },
   };

--- a/src/categories.js
+++ b/src/categories.js
@@ -1,8 +1,8 @@
 import { defaultMethods } from './utils';
 import cache from './cache';
 
-function methods(request) {
-  const { get, list } = defaultMethods(request, '/categories', ['list', 'get']);
+function methods(api) {
+  const { get, list } = defaultMethods(api, '/categories', ['list', 'get']);
 
   return {
     get: (id, ...args) => {

--- a/src/content.js
+++ b/src/content.js
@@ -1,17 +1,18 @@
 import cache from './cache';
 
-function methods(request, opt) {
+function methods(api, opt) {
   return {
     get: (type, id, query) => {
       return cache.getFetch(`content_${type}`, id, () =>
-        request('get', `/content/${type}`, id, {
+        api.request('get', `/content/${type}`, id, {
           $preview: opt.previewContent,
           ...(query || {}),
         }),
       );
     },
 
-    list: (type, query) => request('get', `/content/${type}`, undefined, query),
+    list: (type, query) =>
+      api.request('get', `/content/${type}`, undefined, query),
   };
 }
 

--- a/src/currency.js
+++ b/src/currency.js
@@ -2,7 +2,7 @@ import { get, find, round } from './utils';
 
 const FORMATTERS = {};
 
-function methods(request, opt) {
+function methods(api, opt) {
   return {
     code: null,
     state: null,
@@ -15,7 +15,7 @@ function methods(request, opt) {
     async select(currency) {
       this.set(currency);
 
-      return request('put', '/session', { currency });
+      return api.request('put', '/session', { currency });
     },
 
     selected() {

--- a/src/functions.js
+++ b/src/functions.js
@@ -1,4 +1,4 @@
-function methods(request, _opt) {
+function methods(api, _opt) {
   return {
     /**
      * Make a request to an app function and greceiveet a response
@@ -10,7 +10,7 @@ function methods(request, _opt) {
      * @returns {any}
      */
     request(method, appId, functionName, data, options = undefined) {
-      return request(method, functionName, undefined, data, {
+      return api.request(method, functionName, undefined, data, {
         ...options,
         path: `/functions/${appId}`,
         useCamelCase: false, // avoid mutating data

--- a/src/invoices.js
+++ b/src/invoices.js
@@ -1,8 +1,8 @@
 import { defaultMethods } from './utils';
 import cache from './cache';
 
-function methods(request) {
-  const { get, list } = defaultMethods(request, '/invoices', ['list', 'get']);
+function methods(api) {
+  const { get, list } = defaultMethods(api, '/invoices', ['list', 'get']);
   return {
     get: (id, ...args) => {
       return cache.getFetch('invoices', id, () => get(id, ...args));

--- a/src/locale.js
+++ b/src/locale.js
@@ -1,6 +1,6 @@
 import { find } from './utils';
 
-function methods(request, opt) {
+function methods(api, opt) {
   return {
     code: null,
     state: null,
@@ -13,7 +13,7 @@ function methods(request, opt) {
       this.set(locale);
       opt.setCookie('swell-locale', locale);
       opt.api.settings.locale = locale;
-      return await request('put', '/session', { locale });
+      return await api.request('put', '/session', { locale });
     },
 
     selected() {

--- a/src/payment/amazon/amazon.js
+++ b/src/payment/amazon/amazon.js
@@ -7,8 +7,8 @@ import {
 } from '../../utils/errors';
 
 export default class AmazonDirectPayment extends Payment {
-  constructor(request, options, params, methods) {
-    super(request, options, params, methods.amazon);
+  constructor(api, options, params, methods) {
+    super(api, options, params, methods.amazon);
   }
 
   get scripts() {

--- a/src/payment/apple/braintree.js
+++ b/src/payment/apple/braintree.js
@@ -12,12 +12,12 @@ const MERCHANT_CAPABILITIES = [
 ];
 
 export default class BraintreeApplePayment extends Payment {
-  constructor(request, options, params, methods) {
+  constructor(api, options, params, methods) {
     if (!methods.card) {
       throw new PaymentMethodDisabledError('Credit cards');
     }
 
-    super(request, options, params, methods.apple);
+    super(api, options, params, methods.apple);
   }
 
   get scripts() {

--- a/src/payment/apple/stripe.js
+++ b/src/payment/apple/stripe.js
@@ -9,7 +9,7 @@ import {
 /** @typedef {import('@stripe/stripe-js').PaymentRequestPaymentMethodEvent} PaymentRequestPaymentMethodEvent */
 
 export default class StripeApplePayment extends Payment {
-  constructor(request, options, params, methods) {
+  constructor(api, options, params, methods) {
     if (!methods.card) {
       throw new PaymentMethodDisabledError('Credit cards');
     }
@@ -19,7 +19,7 @@ export default class StripeApplePayment extends Payment {
       publishable_key: methods.card.publishable_key,
     };
 
-    super(request, options, params, method);
+    super(api, options, params, method);
   }
 
   get scripts() {

--- a/src/payment/bancontact/stripe.js
+++ b/src/payment/bancontact/stripe.js
@@ -9,7 +9,7 @@ import {
 /** @typedef {import('@stripe/stripe-js').Stripe} Stripe */
 
 export default class StripeBancontactPayment extends Payment {
-  constructor(request, options, params, methods) {
+  constructor(api, options, params, methods) {
     if (!methods.card) {
       throw new PaymentMethodDisabledError('Credit cards');
     }
@@ -19,7 +19,7 @@ export default class StripeBancontactPayment extends Payment {
       publishable_key: methods.card.publishable_key,
     };
 
-    super(request, options, params, method);
+    super(api, options, params, method);
   }
 
   get scripts() {

--- a/src/payment/card/quickpay.js
+++ b/src/payment/card/quickpay.js
@@ -2,8 +2,8 @@ import Payment from '../payment';
 import { UnableAuthenticatePaymentMethodError } from '../../utils/errors';
 
 export default class QuickpayCardPayment extends Payment {
-  constructor(request, options, params, methods) {
-    super(request, options, params, methods.card);
+  constructor(api, options, params, methods) {
+    super(api, options, params, methods.card);
   }
 
   get orderId() {

--- a/src/payment/card/stripe.js
+++ b/src/payment/card/stripe.js
@@ -12,8 +12,8 @@ import { LibraryNotLoadedError } from '../../utils/errors';
 /** @typedef {import('@stripe/stripe-js').StripeCardNumberElement} StripeCardNumberElement */
 
 export default class StripeCardPayment extends Payment {
-  constructor(request, options, params, methods) {
-    super(request, options, params, methods.card);
+  constructor(api, options, params, methods) {
+    super(api, options, params, methods.card);
   }
 
   get scripts() {

--- a/src/payment/google/braintree.js
+++ b/src/payment/google/braintree.js
@@ -18,12 +18,12 @@ const ALLOWED_CARD_NETWORKS = [
 ];
 
 export default class BraintreeGooglePayment extends Payment {
-  constructor(request, options, params, methods) {
+  constructor(api, options, params, methods) {
     if (!methods.card) {
       throw new PaymentMethodDisabledError('Credit cards');
     }
 
-    super(request, options, params, methods.google);
+    super(api, options, params, methods.google);
   }
 
   get scripts() {

--- a/src/payment/google/stripe.js
+++ b/src/payment/google/stripe.js
@@ -9,7 +9,7 @@ import {
 /** @typedef {import('@stripe/stripe-js').PaymentRequestPaymentMethodEvent} PaymentRequestPaymentMethodEvent */
 
 export default class StripeGooglePayment extends Payment {
-  constructor(request, options, params, methods) {
+  constructor(api, options, params, methods) {
     if (!methods.card) {
       throw new PaymentMethodDisabledError('Credit cards');
     }
@@ -19,7 +19,7 @@ export default class StripeGooglePayment extends Payment {
       publishable_key: methods.card.publishable_key,
     };
 
-    super(request, options, params, method);
+    super(api, options, params, method);
   }
 
   get scripts() {

--- a/src/payment/ideal/stripe.js
+++ b/src/payment/ideal/stripe.js
@@ -13,7 +13,7 @@ import {
 /** @typedef {import('@stripe/stripe-js').StripeIdealBankElement} StripeIdealBankElement */
 
 export default class StripeIDealPayment extends Payment {
-  constructor(request, options, params, methods) {
+  constructor(api, options, params, methods) {
     if (!methods.card) {
       throw new PaymentMethodDisabledError('Credit cards');
     }
@@ -23,7 +23,7 @@ export default class StripeIDealPayment extends Payment {
       publishable_key: methods.card.publishable_key,
     };
 
-    super(request, options, params, method);
+    super(api, options, params, method);
   }
 
   get scripts() {

--- a/src/payment/index.js
+++ b/src/payment/index.js
@@ -28,14 +28,14 @@ import {
 } from '../utils';
 
 export default class PaymentController {
-  constructor(request, options) {
-    this.request = request;
+  constructor(api, options) {
+    this.api = api;
     this.options = options;
-    this.payment = new Payment(this.request, this.options);
+    this.payment = new Payment(this.api, this.options);
   }
 
   get(id) {
-    return this.request('get', '/payments', id);
+    return this.api.request('get', '/payments', id);
   }
 
   async methods() {
@@ -43,7 +43,7 @@ export default class PaymentController {
       return this.methodSettings;
     }
 
-    this.methodSettings = await this.request('get', '/payment/methods');
+    this.methodSettings = await this.api.request('get', '/payment/methods');
 
     return this.methodSettings;
   }
@@ -126,7 +126,7 @@ export default class PaymentController {
       }
 
       const paymentInstance = new PaymentClass(
-        this.request,
+        this.api,
         this.options,
         null,
         paymentMethods,
@@ -165,10 +165,7 @@ export default class PaymentController {
   }
 
   async _getPaymentMethods() {
-    const paymentMethods = await settingsApi(
-      this.request,
-      this.options,
-    ).payments();
+    const paymentMethods = await settingsApi(this.api, this.options).payments();
 
     if (paymentMethods.error) {
       throw new Error(paymentMethods.error);
@@ -226,7 +223,7 @@ export default class PaymentController {
 
       try {
         const paymentInstance = new PaymentClass(
-          this.request,
+          this.api,
           this.options,
           methodParams,
           paymentMethods,

--- a/src/payment/klarna/klarna.js
+++ b/src/payment/klarna/klarna.js
@@ -3,8 +3,8 @@ import { getKlarnaSessionData } from '../../utils/klarna';
 import { UnableAuthenticatePaymentMethodError } from '../../utils/errors';
 
 export default class KlarnaDirectPayment extends Payment {
-  constructor(request, options, params, methods) {
-    super(request, options, params, methods.klarna);
+  constructor(api, options, params, methods) {
+    super(api, options, params, methods.klarna);
   }
 
   async tokenize() {

--- a/src/payment/klarna/stripe.js
+++ b/src/payment/klarna/stripe.js
@@ -12,7 +12,7 @@ import {
 /** @typedef {import('@stripe/stripe-js').Stripe} Stripe */
 
 export default class StripeKlarnaPayment extends Payment {
-  constructor(request, options, params, methods) {
+  constructor(api, options, params, methods) {
     if (!methods.card) {
       throw new PaymentMethodDisabledError('Credit cards');
     }
@@ -22,7 +22,7 @@ export default class StripeKlarnaPayment extends Payment {
       publishable_key: methods.card.publishable_key,
     };
 
-    super(request, options, params, method);
+    super(api, options, params, method);
   }
 
   get scripts() {

--- a/src/payment/payment.js
+++ b/src/payment/payment.js
@@ -18,8 +18,8 @@ export default class Payment {
   _element = null;
   _elementContainer = null;
 
-  constructor(request, options, params, method) {
-    this.request = request;
+  constructor(api, options, params, method) {
+    this.api = api;
     this.options = options;
     this.params = params;
     this.method = method;
@@ -85,7 +85,7 @@ export default class Payment {
    * @returns {Promise<object>}
    */
   async getCart() {
-    const cart = await cartApi(this.request, this.options).get();
+    const cart = await cartApi(this.api, this.options).get();
 
     if (!cart) {
       throw new Error('Cart not found');
@@ -113,7 +113,7 @@ export default class Payment {
       }
     }
 
-    const updatedCart = await cartApi(this.request, this.options).update(
+    const updatedCart = await cartApi(this.api, this.options).update(
       updateData,
     );
 
@@ -126,7 +126,7 @@ export default class Payment {
    * @returns {Promise<object>}
    */
   async getSettings() {
-    return settingsApi(this.request, this.options).get();
+    return settingsApi(this.api, this.options).get();
   }
 
   /**
@@ -166,7 +166,9 @@ export default class Payment {
    * @returns {Promise<object>}
    */
   resetAsyncPayment(id) {
-    return this.request('put', '/payments', id, { $reset_async_payment: true });
+    return this.api.request('put', '/payments', id, {
+      $reset_async_payment: true,
+    });
   }
 
   /**

--- a/src/payment/paypal/braintree.js
+++ b/src/payment/paypal/braintree.js
@@ -2,8 +2,8 @@ import Payment from '../payment';
 import { LibraryNotLoadedError } from '../../utils/errors';
 
 export default class BraintreePaypalPayment extends Payment {
-  constructor(request, options, params, methods) {
-    super(request, options, params, methods.paypal);
+  constructor(api, options, params, methods) {
+    super(api, options, params, methods.paypal);
   }
 
   get scripts() {

--- a/src/payment/paypal/paypal.js
+++ b/src/payment/paypal/paypal.js
@@ -3,8 +3,8 @@ import { get, isEmpty } from '../../utils';
 import { LibraryNotLoadedError } from '../../utils/errors';
 
 export default class PaypalDirectPayment extends Payment {
-  constructor(request, options, params, methods) {
-    super(request, options, params, methods.paypal);
+  constructor(api, options, params, methods) {
+    super(api, options, params, methods.paypal);
   }
 
   get scripts() {

--- a/src/payment/paysafecard/paysafecard.js
+++ b/src/payment/paysafecard/paysafecard.js
@@ -4,8 +4,8 @@ import { createPaysafecardPaymentData } from '../../utils/paysafecard';
 import { UnableAuthenticatePaymentMethodError } from '../../utils/errors';
 
 export default class PaysafecardDirectPayment extends Payment {
-  constructor(request, options, params, methods) {
-    super(request, options, params, methods.paysafecard);
+  constructor(api, options, params, methods) {
+    super(api, options, params, methods.paysafecard);
   }
 
   async tokenize() {

--- a/src/products.js
+++ b/src/products.js
@@ -14,9 +14,9 @@ import attributesApi from './attributes';
 
 let OPTIONS;
 
-function methods(request, opt) {
+function methods(api, opt) {
   OPTIONS = opt;
-  const { get, list } = defaultMethods(request, '/products', ['list', 'get']);
+  const { get, list } = defaultMethods(api, '/products', ['list', 'get']);
   return {
     get: (id, ...args) => {
       return cache.getFetch('products', id, () => get(id, ...args));
@@ -35,7 +35,7 @@ function methods(request, opt) {
     filters: getFilters,
 
     filterableAttributeFilters: (products, options) =>
-      getFilterableAttributeFilters(request, products, options),
+      getFilterableAttributeFilters(api, products, options),
   };
 }
 
@@ -239,9 +239,9 @@ function findPurchaseOption(product, purchaseOption) {
   };
 }
 
-async function getFilterableAttributeFilters(request, products, options) {
+async function getFilterableAttributeFilters(api, products, options) {
   const { results: filterableAttributes } = await attributesApi(
-    request,
+    api,
     OPTIONS,
   ).list({
     filterable: true,

--- a/src/session.js
+++ b/src/session.js
@@ -1,10 +1,10 @@
-function methods(request, opt) {
+function methods(api, opt) {
   return {
     /**
      * Get the decoded session as an object of session values
      */
     get() {
-      return request('get', '/session');
+      return api.request('get', '/session');
     },
 
     /**

--- a/src/settings.js
+++ b/src/settings.js
@@ -9,7 +9,7 @@ import {
   camelCase,
 } from './utils';
 
-function methods(request, opt) {
+function methods(api, opt) {
   return {
     state: null,
     menuState: null,
@@ -34,7 +34,7 @@ function methods(request, opt) {
       { id = undefined, def = undefined, refresh = false } = {},
     ) {
       if (!this[stateName] || refresh) {
-        this[stateName] = request('get', uri);
+        this[stateName] = api.request('get', uri);
       }
       if (this[stateName] && typeof this[stateName].then === 'function') {
         return this[stateName].then((state) => {
@@ -157,7 +157,7 @@ function methods(request, opt) {
     async load() {
       try {
         const { settings, menus, payments, subscriptions, session } =
-          await request('get', '/settings/all');
+          await api.request('get', '/settings/all');
 
         this.localizedState = {};
 

--- a/src/subscriptions.js
+++ b/src/subscriptions.js
@@ -2,11 +2,8 @@ import { cleanProductOptions } from './products';
 import { defaultMethods } from './utils';
 import cache from './cache';
 
-function methods(request) {
-  const { get, list } = defaultMethods(request, '/subscriptions', [
-    'list',
-    'get',
-  ]);
+function methods(api) {
+  const { get, list } = defaultMethods(api, '/subscriptions', ['list', 'get']);
   return {
     get: (id, ...args) => {
       return cache.getFetch('subscriptions', id, () => get(id, ...args));
@@ -30,15 +27,19 @@ function methods(request) {
     },
 
     create(data) {
-      return request('post', '/subscriptions', this.getCleanData(data));
+      return api.request('post', '/subscriptions', this.getCleanData(data));
     },
 
     update(id, data) {
-      return request('put', `/subscriptions/${id}`, this.getCleanData(data));
+      return api.request(
+        'put',
+        `/subscriptions/${id}`,
+        this.getCleanData(data),
+      );
     },
 
     addItem(id, item) {
-      return request(
+      return api.request(
         'post',
         `/subscriptions/${id}/items`,
         this.getCleanData(item),
@@ -49,11 +50,11 @@ function methods(request) {
       if (items && items.map) {
         items = items.map(this.getCleanData);
       }
-      return request('put', `/subscriptions/${id}/items`, items);
+      return api.request('put', `/subscriptions/${id}/items`, items);
     },
 
     updateItem(id, itemId, item) {
-      return request(
+      return api.request(
         'put',
         `/subscriptions/${id}/items/${itemId}`,
         this.getCleanData(item),
@@ -61,7 +62,7 @@ function methods(request) {
     },
 
     removeItem(id, itemId) {
-      return request('delete', `/subscriptions/${id}/items/${itemId}`);
+      return api.request('delete', `/subscriptions/${id}/items/${itemId}`);
     },
   };
 }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -128,19 +128,19 @@ function isFunction(func) {
   return typeof func === 'function';
 }
 
-function defaultMethods(request, uri, methods) {
+function defaultMethods(api, uri, methods) {
   return {
     list:
       methods.indexOf('list') >= 0
         ? function (query) {
-            return request('get', uri, undefined, query);
+            return api.request('get', uri, undefined, query);
           }
         : undefined,
 
     get:
       methods.indexOf('get') >= 0
         ? function (id, query) {
-            return request('get', uri, id, query);
+            return api.request('get', uri, id, query);
           }
         : undefined,
   };

--- a/test/payment/card-stripe.test.js
+++ b/test/payment/card-stripe.test.js
@@ -53,7 +53,7 @@ describePayment('payment/card/stripe', (_request, options, _paymentMock) => {
         };
       };
 
-      const payment = new PaymentController(request, options);
+      const payment = new PaymentController({ request }, options);
 
       const paymentId = 'test_payment_id';
 

--- a/test/payment/utils.js
+++ b/test/payment/utils.js
@@ -1,8 +1,8 @@
 import mockPayment from '../../mocks/payment';
 
 jest.mock('../../src/payment/payment.js', () => {
-  return function (request, options, params, method) {
-    this.request = request;
+  return function (api, options, params, method) {
+    this.api = api;
     this.options = options;
     this.params = params;
     this.method = method;
@@ -40,6 +40,6 @@ export function describePayment(description, callback) {
       clearGlobal();
     });
 
-    callback(request, options, mockPayment);
+    callback({ request }, options, mockPayment);
   });
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -54,6 +54,12 @@ export * from './subscription';
 
 export as namespace swell;
 
+export function create(
+  store?: string,
+  key?: string,
+  options?: InitOptions,
+): swell;
+
 export type SnakeToCamelCase<S> = S extends `${infer T}_${infer U}`
   ? `${T}${Capitalize<SnakeToCamelCase<U>>}`
   : S;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -53,12 +53,13 @@ export * from './shipment_rating';
 export * from './subscription';
 
 export as namespace swell;
+export type SwellClient = typeof import('.');
 
 export function create(
   store?: string,
   key?: string,
   options?: InitOptions,
-): swell;
+): SwellClient;
 
 export type SnakeToCamelCase<S> = S extends `${infer T}_${infer U}`
   ? `${T}${Capitalize<SnakeToCamelCase<U>>}`
@@ -485,7 +486,7 @@ import _toNumber from 'lodash-es/toNumber';
 import _toLower from 'lodash-es/toLower';
 import _isEqual from 'lodash-es/isEqual';
 import _isEmpty from 'lodash-es/isEmpty';
-import deepmerge from 'deepmerge';
+import * as deepmerge from 'deepmerge';
 
 export namespace utils {
   export {


### PR DESCRIPTION
- Instead of passing `request` to each initializer, we pass the API instance directly and have those methods use `api.request`
- Export a default uninitialized instance like before, but add a method to that instance `create()` in order to support creating multiple instances at once