### PR TITLE
Fix assert Error on Build in Node 22+

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,8 +3,13 @@ import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import nodePolyfills from 'rollup-plugin-polyfill-node';
 import filesize from 'rollup-plugin-filesize';
+import fs from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-import pkg from './package.json' assert { type: 'json' };
+const pkgPath = join(dirname(fileURLToPath(import.meta.url)), 'package.json');
+
+const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
 
 const deps = Object.keys(pkg.dependencies);
 


### PR DESCRIPTION
Newer versions of node do not support importing with the `assert` syntax and instead use `with` but this breaks the build on versions of node older than 22.

To preserve compatibility with all node versions this code reads and parses the package.json file explicitly.