### PR TITLE
fix: provide a placeholder for Google Pay if the delivery address is not specified

### DIFF
--- a/src/payment/google.js
+++ b/src/payment/google.js
@@ -48,7 +48,7 @@ export async function onPaymentDataChanged(intermediatePaymentData) {
         );
       }
 
-      if (cart.shipment_rating?.services?.length <= 0) {
+      if (!cart.shipment_rating?.services?.length) {
         return createError(
           intermediatePaymentData.callbackTrigger,
           'SHIPPING_ADDRESS_UNSERVICEABLE',
@@ -248,7 +248,7 @@ export function getShippingOptionParameters(cart) {
     return undefined;
   }
 
-  if (!shipment_rating) {
+  if (!shipment_rating?.services?.length) {
     return {
       defaultSelectedOptionId: 'unknown',
       shippingOptions: [


### PR DESCRIPTION
https://app.asana.com/1/1126683767705082/project/1203548350351764/task/1211451963048304?focus=true

Provide a shipment placeholder for Google Pay if the shipping address is not specified.