### PR TITLE
feat: implement Google Pay for ConvesioPay gateway

### DIFF
--- a/src/card.js
+++ b/src/card.js
@@ -65,7 +65,7 @@ const cardApi = {
     const currentYear = new Date().getUTCFullYear().toString();
     let strYear = parts[1];
 
-    if (strYear.length !== currentYear.length) {
+    if (strYear.length < currentYear.length) {
       let fullYear =
         currentYear.slice(0, currentYear.length - strYear.length) + strYear;
 
@@ -87,17 +87,14 @@ const cardApi = {
   },
 
   types() {
-    let e, t, n, r;
-    t = {};
-    for (e = n = 40; n <= 49; e = ++n) t[e] = 'Visa';
-    for (e = r = 50; r <= 59; e = ++r) t[e] = 'MasterCard';
-    return (
-      (t[34] = t[37] = 'American Express'),
-      (t[60] = t[62] = t[64] = t[65] = 'Discover'),
-      (t[35] = 'JCB'),
-      (t[30] = t[36] = t[38] = t[39] = 'Diners Club'),
-      t
-    );
+    let t = {};
+    for (let e = 40; e <= 49; ++e) t[e] = 'Visa';
+    for (let e = 50; e <= 59; ++e) t[e] = 'MasterCard';
+    t[34] = t[37] = 'American Express';
+    t[60] = t[62] = t[64] = t[65] = 'Discover';
+    t[35] = 'JCB';
+    t[30] = t[36] = t[38] = t[39] = 'Diners Club';
+    return t;
   },
 
   type(num) {
@@ -105,47 +102,67 @@ const cardApi = {
   },
 
   luhnCheck(num) {
-    let t, n, r, i, s, o;
-    (r = !0), (i = 0), (n = (num + '').split('').reverse());
-    for (s = 0, o = n.length; s < o; s++) {
-      (t = n[s]), (t = Number.parseInt(t, 10));
-      if ((r = !r)) t *= 2;
-      t > 9 && (t -= 9), (i += t);
+    const numbers = String(num);
+    let odd = false;
+    let sum = 0;
+
+    for (let i = numbers.length - 1; i >= 0; --i) {
+      let digit = Number.parseInt(numbers[i], 10);
+
+      if (odd) {
+        digit *= 2;
+
+        if (digit > 9) {
+          digit -= 9;
+        }
+      }
+
+      sum += digit;
+      odd = !odd;
     }
-    return i % 10 === 0;
+
+    return sum % 10 === 0;
   },
 
   validateNumber(num) {
-    return (
-      (num = (num + '').replace(/\s+|-/g, '')),
-      num.length >= 10 && num.length <= 16 && this.luhnCheck(num)
-    );
+    num = String(num).replace(/\s+|-/g, '');
+
+    return num.length >= 10 && num.length <= 16 && this.luhnCheck(num);
   },
 
   validateExpiry(month, year) {
-    let r, i;
-    return (
-      (month = String(month).trim()),
-      (year = String(year).trim()),
-      /^\d+$/.test(month)
-        ? /^\d+$/.test(year)
-          ? Number.parseInt(month, 10) <= 12
-            ? ((i = new Date(year, month)),
-              (r = new Date()),
-              i.setMonth(i.getMonth() - 1),
-              i.setMonth(i.getMonth() + 1, 1),
-              i > r)
-            : !1
-          : !1
-        : !1
-    );
+    month = String(month).trim();
+    year = String(year).trim();
+
+    if (!/^\d+$/.test(month) || !/^\d+$/.test(year)) {
+      return false;
+    }
+
+    const numMonth = Number.parseInt(month, 10);
+
+    if (numMonth <= 0 || numMonth > 12) {
+      return false;
+    }
+
+    const date = new Date(year, month);
+    date.setMonth(date.getMonth() - 1);
+    date.setMonth(date.getMonth() + 1, 1);
+
+    const diff = date.getTime() - Date.now();
+
+    // The card has expired
+    if (diff < 0) {
+      return false;
+    }
+
+    // The card's validity period must not exceed 75 years from the current time.
+    return Math.round(diff / 31_557_600_000) < 75;
   },
 
   validateCVC(val) {
-    return (
-      (val = String(val).trim()),
-      /^\d+$/.test(val) && val.length >= 3 && val.length <= 4
-    );
+    val = String(val).trim();
+
+    return /^\d+$/.test(val) && val.length >= 3 && val.length <= 4;
   },
 };
 

--- a/src/card.js
+++ b/src/card.js
@@ -61,17 +61,28 @@ const cardApi = {
 
     const parts = new String(value).split(/[\s/-]+/, 2);
     const month = parts[0];
-    let year = parts[1];
 
-    // Convert 2 digit year
-    if (year && year.length === 2 && /^\d+$/.test(year)) {
-      const prefix = new Date().getFullYear().toString().substring(0, 2);
-      year = prefix + year;
+    const currentYear = new Date().getUTCFullYear().toString();
+    let strYear = parts[1];
+
+    if (strYear.length !== currentYear.length) {
+      let fullYear =
+        currentYear.slice(0, currentYear.length - strYear.length) + strYear;
+
+      // If the expiration year is less than the current year,
+      // then the expiration year is in the next century.
+      if (fullYear < currentYear) {
+        let year = Number(fullYear);
+        year += 10 ** strYear.length;
+        fullYear = year.toString();
+      }
+
+      strYear = fullYear;
     }
 
     return {
-      month: ~~month,
-      year: ~~year,
+      month: Number.parseInt(month, 10),
+      year: Number.parseInt(strYear, 10),
     };
   },
 
@@ -97,7 +108,7 @@ const cardApi = {
     let t, n, r, i, s, o;
     (r = !0), (i = 0), (n = (num + '').split('').reverse());
     for (s = 0, o = n.length; s < o; s++) {
-      (t = n[s]), (t = parseInt(t, 10));
+      (t = n[s]), (t = Number.parseInt(t, 10));
       if ((r = !r)) t *= 2;
       t > 9 && (t -= 9), (i += t);
     }
@@ -118,7 +129,7 @@ const cardApi = {
       (year = String(year).trim()),
       /^\d+$/.test(month)
         ? /^\d+$/.test(year)
-          ? parseInt(month, 10) <= 12
+          ? Number.parseInt(month, 10) <= 12
             ? ((i = new Date(year, month)),
               (r = new Date()),
               i.setMonth(i.getMonth() - 1),

--- a/src/card.js
+++ b/src/card.js
@@ -155,8 +155,8 @@ const cardApi = {
       return false;
     }
 
-    // The card's validity period must not exceed 75 years from the current time.
-    return Math.round(diff / 31_557_600_000) < 75;
+    // The card's validity period must not exceed 50 years from the current time.
+    return Math.round(diff / 31_557_600_000) < 50;
   },
 
   validateCVC(val) {

--- a/src/card.test.js
+++ b/src/card.test.js
@@ -5,19 +5,26 @@ describe('card', () => {
     api.init('test', 'pk_test');
   });
 
+  /** @param {number} relative */
+  function getExpYear(relative) {
+    return new Date().getUTCFullYear() + relative;
+  }
+
   describe('createToken', () => {
     it('should make request to POST /tokens', async () => {
       fetch.mockResponse(JSON.stringify({ $data: { token: 't_test' } }));
 
+      const exp_year = getExpYear(5);
+
       await api.card.createToken({
         number: '4242 4242 4242 4242',
         exp_month: 1,
-        exp_year: 2099,
+        exp_year,
         cvc: '098',
       });
 
       expect(fetch).toHaveBeenCalledWith(
-        'https://vault.schema.io/tokens?%24jsonp%5Bmethod%5D=post&%24jsonp%5Bcallback%5D=none&%24data%5Bnumber%5D=4242%204242%204242%204242&%24data%5Bexp_month%5D=1&%24data%5Bexp_year%5D=2099&%24data%5Bcvc%5D=098&%24key=pk_test',
+        `https://vault.schema.io/tokens?%24jsonp%5Bmethod%5D=post&%24jsonp%5Bcallback%5D=none&%24data%5Bnumber%5D=4242%204242%204242%204242&%24data%5Bexp_month%5D=1&%24data%5Bexp_year%5D=${exp_year}&%24data%5Bcvc%5D=098&%24key=pk_test`,
         expect.objectContaining({
           signal: expect.any(Object),
         }),
@@ -46,7 +53,7 @@ describe('card', () => {
         api.card.createToken({
           cvc: 123,
           exp_month: 1,
-          exp_year: 2099,
+          exp_year: getExpYear(5),
           number: '1',
         }),
       ).rejects.toThrow('Card number appears to be invalid');
@@ -65,7 +72,7 @@ describe('card', () => {
         api.card.createToken({
           cvc: 123,
           exp_month: 1,
-          exp_year: 2099,
+          exp_year: getExpYear(5),
           number: '4242 4242 4242 4242',
         }),
       ).rejects.toThrow('Test error');
@@ -74,16 +81,33 @@ describe('card', () => {
 
   describe('expiry', () => {
     it('should parse expiration string into parts', () => {
-      const { month, year } = api.card.expiry('01/2099');
+      const exp = api.card.expiry('01/2099');
 
-      expect(month).toEqual(1);
-      expect(year).toEqual(2099);
+      expect(exp).toEqual({ month: 1, year: 2099 });
     });
 
     it('should return existing object', () => {
       const exp = api.card.expiry({ month: 1, year: 2099 });
 
       expect(exp).toEqual({ month: 1, year: 2099 });
+    });
+
+    it('should parse short expiration string into parts', () => {
+      // Future year
+      const year = getExpYear(5);
+      const shortYear = year.toString().slice(-2);
+      expect(shortYear).toHaveLength(2);
+
+      const exp1 = api.card.expiry(`01/${shortYear}`);
+      expect(exp1).toEqual({ month: 1, year });
+
+      // Past years should be counted as years in the next century (+100 years)
+      const pastYear = getExpYear(-5);
+      const shortPastYear = pastYear.toString().slice(-2);
+      expect(shortPastYear).toHaveLength(2);
+
+      const exp2 = api.card.expiry(`01/${shortPastYear}`);
+      expect(exp2).toEqual({ month: 1, year: pastYear + 100 });
     });
   });
 
@@ -134,7 +158,7 @@ describe('card', () => {
 
   describe('validateExpiry', () => {
     it('should validate card expiration date', () => {
-      const year = new Date().getFullYear() + 1;
+      const year = getExpYear(1);
 
       expect(api.card.validateExpiry(9, year)).toStrictEqual(true);
       expect(api.card.validateExpiry('9', `${year}`)).toStrictEqual(true);
@@ -142,13 +166,26 @@ describe('card', () => {
     });
 
     it('should not validate card expiration date', () => {
+      // Empty input
       expect(api.card.validateExpiry()).toStrictEqual(false);
+      // Year is missing
       expect(api.card.validateExpiry(11)).toStrictEqual(false);
-      expect(api.card.validateExpiry(9, 2020)).toStrictEqual(false);
-      expect(api.card.validateExpiry(13, 2020)).toStrictEqual(false);
-      expect(api.card.validateExpiry(13, 9999)).toStrictEqual(false);
-      expect(api.card.validateExpiry('||', 9999)).toStrictEqual(false);
+      // Past year
+      expect(api.card.validateExpiry(9, getExpYear(-1))).toStrictEqual(false);
+      // Month out of range
+      expect(api.card.validateExpiry(13, getExpYear(1))).toStrictEqual(false);
+      expect(api.card.validateExpiry(0, getExpYear(1))).toStrictEqual(false);
+      // The expiration year is too long
+      expect(api.card.validateExpiry(9, getExpYear(100))).toStrictEqual(false);
+      // Invalid month
+      expect(api.card.validateExpiry('||', getExpYear(1))).toStrictEqual(false);
+      // Invalid year
       expect(api.card.validateExpiry(11, '||||')).toStrictEqual(false);
+    });
+
+    it('should only validate expiration dates within 50 years from the current date', () => {
+      expect(api.card.validateExpiry(9, getExpYear(49))).toStrictEqual(true);
+      expect(api.card.validateExpiry(9, getExpYear(51))).toStrictEqual(false);
     });
   });
 

--- a/src/payment/apple.js
+++ b/src/payment/apple.js
@@ -9,7 +9,7 @@
  * @param {ApplePayJS.ApplePayPaymentContact} shippingContact
  * @returns {Promise<ApplePayJS.ApplePayShippingContactUpdate>}
  */
-export async function onShippingAddressChange(shippingContact) {
+async function onShippingAddressChange(shippingContact) {
   try {
     // Update cart with Apple Pay shipping address to get shipping options and tax
     // This happens immediately when the sheet opens with the default address
@@ -23,7 +23,7 @@ export async function onShippingAddressChange(shippingContact) {
         'Shipping is not available for the provided address.';
 
       return {
-        newTotal: getTotal(cart),
+        newTotal: getTotal(cart, this.merchantInfo),
         newLineItems: getLineItems(cart),
         newShippingMethods: [], // REQUIRED: Must always provide this, even as empty array
         errors: [
@@ -34,7 +34,7 @@ export async function onShippingAddressChange(shippingContact) {
 
     // Success: Return updated totals and shipping methods
     return {
-      newTotal: getTotal(cart),
+      newTotal: getTotal(cart, this.merchantInfo),
       newLineItems: getLineItems(cart),
       newShippingMethods: getShippingMethods(cart),
     };
@@ -42,7 +42,7 @@ export async function onShippingAddressChange(shippingContact) {
     const cartData = await this.getCart();
 
     return {
-      newTotal: getTotal(cartData),
+      newTotal: getTotal(cartData, this.merchantInfo),
       newLineItems: getLineItems(cartData),
       newShippingMethods: [], // REQUIRED: Must always provide this, even as empty array
       errors: [new ApplePayError('unknown', undefined, err.message)],
@@ -79,7 +79,7 @@ export async function onShippingContactSelected(session, event) {
  * @param {ApplePayJS.ApplePayShippingMethod} shippingMethod
  * @returns {Promise<ApplePayJS.ApplePayShippingMethodUpdate>}
  */
-export async function onShippingMethodChange(shippingMethod) {
+async function onShippingMethodChange(shippingMethod) {
   try {
     const cart = await this.updateCart({
       shipping: {
@@ -88,12 +88,12 @@ export async function onShippingMethodChange(shippingMethod) {
     });
 
     return {
-      newTotal: getTotal(cart),
+      newTotal: getTotal(cart, this.merchantInfo),
       newLineItems: getLineItems(cart),
     };
   } catch (err) {
     return {
-      newTotal: getTotal(await this.getCart()),
+      newTotal: getTotal(await this.getCart(), this.merchantInfo),
       errors: [new ApplePayError('unknown', undefined, err.message)],
     };
   }
@@ -121,6 +121,34 @@ export async function onShippingMethodSelected(session, event) {
 }
 
 /**
+ * @this {Payment}
+ * @param {string} [couponCode]
+ * @returns {Promise<ApplePayJS.ApplePayCouponCodeUpdate>}
+ */
+async function onCouponCodeUpdated(couponCode) {
+  try {
+    const cart = await this.updateCart({
+      coupon_code: couponCode || null,
+    });
+
+    // Valid coupon applied successfully
+    return {
+      newTotal: getTotal(cart, this.merchantInfo),
+      newLineItems: getLineItems(cart),
+    };
+  } catch (err) {
+    // HTTP 400 error from invalid coupon - get fresh cart state
+    const currentCart = await this.getCart();
+
+    return {
+      newTotal: getTotal(currentCart, this.merchantInfo),
+      newLineItems: getLineItems(currentCart),
+      errors: [new ApplePayError('couponCodeInvalid', undefined, err.message)],
+    };
+  }
+}
+
+/**
  * Handles Apple Pay coupon code changes
  *
  * Triggered when the user enters or removes a coupon code in the Apple Pay sheet.
@@ -132,26 +160,9 @@ export async function onShippingMethodSelected(session, event) {
  * @returns {void}
  */
 export async function onCouponCodeChanged(session, event) {
-  try {
-    const cart = await this.updateCart({
-      coupon_code: event.couponCode || null,
-    });
-
-    // Valid coupon applied successfully
-    session.completeCouponCodeChange({
-      newTotal: getTotal(cart),
-      newLineItems: getLineItems(cart),
-    });
-  } catch (err) {
-    // HTTP 400 error from invalid coupon - get fresh cart state
-    const currentCart = await this.getCart();
-
-    session.completeCouponCodeChange({
-      newTotal: getTotal(currentCart),
-      newLineItems: getLineItems(currentCart),
-      errors: [new ApplePayError('couponCodeInvalid', undefined, err.message)],
-    });
-  }
+  session.completeCouponCodeChange(
+    await onCouponCodeUpdated.call(this, event.couponCode),
+  );
 }
 
 /**
@@ -165,15 +176,11 @@ export async function onCouponCodeChanged(session, event) {
  * then sees the final amount once everything is calculated.
  *
  * @param {Cart} cart
+ * @param {object} [merchantInfo]
  * @returns {ApplePayJS.ApplePayLineItem}
  */
-export function getTotal(cart) {
-  const {
-    settings: { name },
-    capture_total,
-    shipment_delivery,
-    shipping,
-  } = cart;
+export function getTotal(cart, merchantInfo) {
+  const { capture_total, shipment_delivery, shipping } = cart;
 
   // Use 'final' only after shipping method is selected or not needed, otherwise 'pending'
   const isFinalPrice = !shipment_delivery || shipping?.service;
@@ -181,7 +188,7 @@ export function getTotal(cart) {
 
   return {
     // Here the label should contain the company name
-    label: name || 'Company name',
+    label: merchantInfo?.displayName || cart.settings?.name || 'Company name',
     type,
     amount: Number(capture_total || 0).toFixed(2),
   };

--- a/src/payment/apple/abstract.js
+++ b/src/payment/apple/abstract.js
@@ -1,0 +1,308 @@
+/**
+ * Apple Pay Payment Integration for Authorize.Net Gateway
+ *
+ * This implementation integrates Apple Pay with Swell using Authorize.Net as the payment processor.
+ *
+ * KEY IMPLEMENTATION DETAILS:
+ *
+ * 1. SHIPPING ADDRESS HANDLING:
+ *    - Apple Pay is the ONLY source of shipping address
+ *    - Any pre-existing shipping data from checkout forms is cleared before initialization
+ *    - When Apple Pay sheet opens, it immediately fires 'shippingcontactselected' with default address
+ *    - Each address change triggers recalculation of shipping options and tax
+ *
+ * 2. PAYMENT FLOW:
+ *    - User clicks Apple Pay button → Sheet opens
+ *    - User confirms address/shipping → Calculations update in real-time
+ *    - User authorizes with Face ID/Touch ID → Payment token stored in cart
+ *    - User must manually click "Place Order" to submit (no auto-processing)
+ *
+ * 3. TOTAL DISPLAY:
+ *    - Shows "Amount Pending" until shipping method selected
+ *    - Shows actual amount after shipping selected (type: 'pending' → 'final')
+ *
+ * @see https://developer.apple.com/documentation/applepayontheweb/apple-pay-js-api
+ */
+
+import {
+  PaymentMethodDisabledError,
+  LibraryNotLoadedError,
+} from '../../utils/errors';
+
+import {
+  getTotal,
+  getLineItems,
+  onCouponCodeChanged,
+  onShippingMethodSelected,
+  onShippingContactSelected,
+} from '../apple';
+
+import Payment from '../payment';
+
+/** @typedef {import('../../../types').Cart} Cart */
+
+/* global ApplePayError */
+
+const VERSION = 14;
+
+export default class AbstractApplePayment extends Payment {
+  constructor(api, options, params, methods) {
+    if (!methods.card) {
+      throw new PaymentMethodDisabledError('Credit cards');
+    }
+
+    super(api, options, params, methods.apple);
+
+    this.merchantInfo = null;
+  }
+
+  get scripts() {
+    return ['apple-pay'];
+  }
+
+  /** @returns {typeof ApplePaySession} */
+  get ApplePaySession() {
+    if (!window.ApplePaySession) {
+      throw new LibraryNotLoadedError('Apple');
+    }
+
+    return window.ApplePaySession;
+  }
+
+  /** @returns {string[]} */
+  getSupportedCardNetworks() {
+    return ['amex', 'discover', 'interac', 'jcb', 'masterCard', 'visa'];
+  }
+
+  /** @returns {ApplePayJS.ApplePayMerchantCapability[]} */
+  getMerchantCapabilities() {
+    return ['supports3DS', 'supportsDebit', 'supportsCredit'];
+  }
+
+  /**
+   * Creates the Apple Pay payment request object
+   *
+   * IMPORTANT: countryCode here is the MERCHANT's country (where your business is located),
+   * NOT the customer's country. Customer country comes from shippingContact.countryCode.
+   *
+   * NOTE: We do NOT pass shippingMethods in the initial request. Shipping methods
+   * are provided dynamically after the user selects/confirms their address in the
+   * 'shippingcontactselected' event handler.
+   *
+   * @param {Cart} cart
+   * @returns {ApplePayJS.ApplePayPaymentRequest}
+   */
+  _createPaymentRequest(cart) {
+    cart = { ...cart };
+
+    const { require = {} } = this.params;
+    const {
+      settings: { country },
+      currency,
+    } = cart;
+
+    const requiredShippingContactFields = [];
+    const requiredBillingContactFields = ['postalAddress'];
+
+    if (require.name) {
+      requiredShippingContactFields.push('name');
+    }
+
+    if (require.email) {
+      requiredShippingContactFields.push('email');
+    }
+
+    if (require.phone) {
+      requiredShippingContactFields.push('phone');
+    }
+
+    if (require.shipping) {
+      requiredShippingContactFields.push('postalAddress');
+    }
+
+    // When initiating a payment request,
+    // we should not display the shipping cost, as it will be calculated later.
+    cart.shipment_price = 0;
+    cart.shipping = {};
+
+    return {
+      total: getTotal(cart, this.merchantInfo),
+      countryCode: country, // Merchant's country
+      currencyCode: currency,
+      supportedNetworks: this.getSupportedCardNetworks(),
+      merchantCapabilities: this.getMerchantCapabilities(),
+      requiredShippingContactFields,
+      requiredBillingContactFields,
+      supportsCouponCode: true,
+      lineItems: getLineItems(cart),
+    };
+  }
+
+  /** @param {Cart} cart */
+  async getApplePayMerchantInfo(cart) {
+    this.merchantInfo = {
+      displayName: cart.settings.name || '',
+    };
+  }
+
+  /** @param {ApplePayJS.ApplePayValidateMerchantEvent} event */
+  // eslint-disable-next-line no-unused-vars
+  async createMerchantSession(event) {
+    throw new Error('Implement this!');
+  }
+
+  /**
+   * @param {ApplePayJS.ApplePayPaymentAuthorizedEvent} event
+   * @returns {Promise<object>}
+   */
+  // eslint-disable-next-line no-unused-vars
+  async preparePaymentDataForCartUpdate(event) {
+    throw new Error('Implement this!');
+  }
+
+  /**
+   * Creates and configures the Apple Pay session with all event handlers
+   *
+   * Event handlers:
+   * - validatemerchant: Validates with Authorize.Net to authorize this domain
+   * - shippingcontactselected: Updates cart when user selects/changes address
+   * - shippingmethodselected: Updates cart when user selects shipping method
+   * - couponcodechanged: Applies/removes coupon codes
+   * - paymentauthorized: Stores payment token and prepares cart for submission
+   *
+   * @param {ApplePayJS.ApplePayPaymentRequest} paymentRequest
+   */
+  async _createPaymentSession(paymentRequest) {
+    const session = new this.ApplePaySession(VERSION, paymentRequest);
+
+    // VALIDATEMERCHANT: Required to authorize this domain with Apple Pay
+    session.onvalidatemerchant = async (event) => {
+      try {
+        const merchantSession = await this.createMerchantSession(event);
+
+        if (merchantSession) {
+          session.completeMerchantValidation(merchantSession);
+        } else {
+          session.abort();
+        }
+      } catch (err) {
+        console.error('[Apple Pay] Merchant validation error:', err);
+        session.abort();
+      }
+    };
+
+    session.onshippingcontactselected = onShippingContactSelected.bind(
+      this,
+      session,
+    );
+
+    session.onshippingmethodselected = onShippingMethodSelected.bind(
+      this,
+      session,
+    );
+
+    session.oncouponcodechanged = onCouponCodeChanged.bind(this, session);
+
+    // PAYMENTAUTHORIZED: User confirmed payment with Face ID/Touch ID
+    // This is where we store the payment token in the cart
+    session.onpaymentauthorized = async (event) => {
+      try {
+        // CRITICAL: Apple Pay addresses are the ONLY addresses we use
+        // - shippingContact: For shipping address (already validated in shippingcontactselected)
+        // - billingContact: For billing address (can be different from shipping)
+        // - email: From shippingContact.emailAddress
+        //
+        // We store the payment token but DO NOT process the order yet.
+        // The user must manually click "Place Order" to complete the transaction.
+        await this.preparePaymentDataForCartUpdate(event).then((data) =>
+          this.updateCart(data),
+        );
+
+        // Complete Apple Pay session successfully
+        // This closes the Apple Pay sheet and shows success to the user
+        session.completePayment({
+          status: this.ApplePaySession.STATUS_SUCCESS,
+        });
+
+        // Notify that Apple Pay authorization is complete
+        // The cart now has the payment token and is ready for submission
+        // NOTE: This does NOT submit the order - user must click "Place Order"
+        this.onSuccess();
+      } catch (err) {
+        session.completePayment({
+          status: this.ApplePaySession.STATUS_FAILURE,
+          errors: new ApplePayError('unknown', undefined, err.message),
+        });
+
+        this.onError(err);
+      }
+    };
+
+    session.begin();
+  }
+
+  /** @param {ApplePayJS.ApplePayPaymentRequest} paymentRequest */
+  _createButton(paymentRequest) {
+    const { style: { type = 'plain', theme = 'black', height = '40px' } = {} } =
+      this.params;
+
+    const button = document.createElement('apple-pay-button');
+
+    button.setAttribute('buttonstyle', theme);
+    button.setAttribute('type', type);
+    button.style.setProperty('--apple-pay-button-width', '100%');
+    button.style.setProperty('--apple-pay-button-height', height);
+
+    button.addEventListener(
+      'click',
+      this._createPaymentSession.bind(this, paymentRequest),
+    );
+
+    return button;
+  }
+
+  /**
+   * Creates the Apple Pay button element
+   *
+   * The button is created but NOT clicked yet. When clicked, it will:
+   * 1. Create a new Apple Pay session
+   * 2. Open the Apple Pay sheet
+   * 3. Handle all payment events (address selection, authorization, etc.)
+   *
+   * @param {Cart} cart
+   */
+  async createElements(cart) {
+    const { elementId = 'applepay-button' } = this.params;
+
+    this.setElementContainer(elementId);
+
+    await Promise.all([
+      this.getApplePayMerchantInfo(cart),
+      this.loadScripts(this.scripts),
+    ]);
+
+    if (!this.ApplePaySession.canMakePayments()) {
+      throw new Error(
+        'This device is not capable of making Apple Pay payments',
+      );
+    }
+
+    const paymentRequest = this._createPaymentRequest(cart);
+
+    this.element = this._createButton(paymentRequest);
+  }
+
+  /**
+   * Mounts the Apple Pay button to the DOM
+   */
+  mountElements() {
+    const { classes = {} } = this.params;
+    const container = this.elementContainer;
+
+    container.appendChild(this.element);
+
+    if (classes.base) {
+      container.classList.add(classes.base);
+    }
+  }
+}

--- a/src/payment/apple/authorizenet.js
+++ b/src/payment/apple/authorizenet.js
@@ -1,316 +1,62 @@
-/**
- * Apple Pay Payment Integration for Authorize.Net Gateway
- *
- * This implementation integrates Apple Pay with Swell using Authorize.Net as the payment processor.
- *
- * KEY IMPLEMENTATION DETAILS:
- *
- * 1. SHIPPING ADDRESS HANDLING:
- *    - Apple Pay is the ONLY source of shipping address
- *    - Any pre-existing shipping data from checkout forms is cleared before initialization
- *    - When Apple Pay sheet opens, it immediately fires 'shippingcontactselected' with default address
- *    - Each address change triggers recalculation of shipping options and tax
- *
- * 2. PAYMENT FLOW:
- *    - User clicks Apple Pay button → Sheet opens
- *    - User confirms address/shipping → Calculations update in real-time
- *    - User authorizes with Face ID/Touch ID → Payment token stored in cart
- *    - User must manually click "Place Order" to submit (no auto-processing)
- *
- * 3. TOTAL DISPLAY:
- *    - Shows "Amount Pending" until shipping method selected
- *    - Shows actual amount after shipping selected (type: 'pending' → 'final')
- *
- * @see https://developer.apple.com/documentation/applepayontheweb/apple-pay-js-api
- */
-
-import Payment from '../payment';
-import {
-  getTotal,
-  getLineItems,
-  convertToSwellAddress,
-  onCouponCodeChanged,
-  onShippingMethodSelected,
-  onShippingContactSelected,
-} from '../apple';
 import { base64Encode } from '../../utils';
-import {
-  PaymentMethodDisabledError,
-  LibraryNotLoadedError,
-} from '../../utils/errors';
 
-/* global ApplePayError */
+import { convertToSwellAddress } from '../apple';
 
-const VERSION = 14;
+import AbstractApplePayment from './abstract';
 
-const MERCHANT_CAPABILITIES = Object.freeze([
-  'supports3DS',
-  'supportsDebit',
-  'supportsCredit',
-]);
+export default class AuthorizeNetApplePayment extends AbstractApplePayment {
+  /**
+   * @override
+   * @param {ApplePayJS.ApplePayValidateMerchantEvent} event
+   */
+  async createMerchantSession(event) {
+    const merchantSession = await this.authorizeGateway({
+      gateway: 'authorizenet',
+      params: {
+        method: 'apple',
+        merchantIdentifier: this.method.merchant_id,
+        validationURL: event.validationURL,
+        displayName: this.merchantInfo.displayName,
+        domainName: window.location.hostname,
+      },
+    });
 
-const ALLOWED_CARD_NETWORKS = Object.freeze([
-  'amex',
-  'discover',
-  'interac',
-  'jcb',
-  'masterCard',
-  'visa',
-]);
-
-export default class AuthorizeNetApplePayment extends Payment {
-  constructor(api, options, params, methods) {
-    if (!methods.card) {
-      throw new PaymentMethodDisabledError('Credit cards');
+    if (merchantSession?.error) {
+      throw new Error(merchantSession.error.message);
     }
 
-    super(api, options, params, methods.apple);
-  }
-
-  get scripts() {
-    return ['apple-pay'];
-  }
-
-  /** @returns {typeof ApplePaySession} */
-  get ApplePaySession() {
-    if (!window.ApplePaySession) {
-      throw new LibraryNotLoadedError('Apple');
-    }
-
-    return window.ApplePaySession;
+    return merchantSession;
   }
 
   /**
-   * Creates the Apple Pay payment request object
-   *
-   * IMPORTANT: countryCode here is the MERCHANT's country (where your business is located),
-   * NOT the customer's country. Customer country comes from shippingContact.countryCode.
-   *
-   * NOTE: We do NOT pass shippingMethods in the initial request. Shipping methods
-   * are provided dynamically after the user selects/confirms their address in the
-   * 'shippingcontactselected' event handler.
-   *
-   * @returns {ApplePayJS.ApplePayPaymentRequest}
+   * @override
+   * @param {ApplePayJS.ApplePayPaymentAuthorizedEvent} event
+   * @returns {Promise<object>}
    */
-  _createPaymentRequest(cart) {
-    cart = { ...cart };
-
-    const { require = {} } = this.params;
+  async preparePaymentDataForCartUpdate(event) {
     const {
-      settings: { country },
-      currency,
-    } = cart;
+      payment: { token, shippingContact, billingContact },
+    } = event;
 
-    const requiredShippingContactFields = [];
-    const requiredBillingContactFields = ['postalAddress'];
-
-    if (require.name) {
-      requiredShippingContactFields.push('name');
-    }
-
-    if (require.email) {
-      requiredShippingContactFields.push('email');
-    }
-
-    if (require.phone) {
-      requiredShippingContactFields.push('phone');
-    }
-
-    if (require.shipping) {
-      requiredShippingContactFields.push('postalAddress');
-    }
-
-    // When initiating a payment request,
-    // we should not display the shipping cost, as it will be calculated later.
-    cart.shipment_price = 0;
-    cart.shipping = {};
+    const { require: { shipping: requireShipping } = {} } = this.params;
 
     return {
-      total: getTotal(cart),
-      countryCode: country, // Merchant's country
-      currencyCode: currency,
-      supportedNetworks: ALLOWED_CARD_NETWORKS,
-      merchantCapabilities: MERCHANT_CAPABILITIES,
-      requiredShippingContactFields,
-      requiredBillingContactFields,
-      supportsCouponCode: true,
-      lineItems: getLineItems(cart),
-    };
-  }
-
-  /**
-   * Creates and configures the Apple Pay session with all event handlers
-   *
-   * Event handlers:
-   * - validatemerchant: Validates with Authorize.Net to authorize this domain
-   * - shippingcontactselected: Updates cart when user selects/changes address
-   * - shippingmethodselected: Updates cart when user selects shipping method
-   * - couponcodechanged: Applies/removes coupon codes
-   * - paymentauthorized: Stores payment token and prepares cart for submission
-   *
-   * @param {ApplePayJS.ApplePayPaymentRequest} paymentRequest
-   */
-  async _createPaymentSession(paymentRequest) {
-    const session = new this.ApplePaySession(VERSION, paymentRequest);
-
-    // VALIDATEMERCHANT: Required to authorize this domain with Apple Pay
-    session.onvalidatemerchant = async (event) => {
-      const merchantSession = await this.authorizeGateway({
-        gateway: 'authorizenet',
-        params: {
-          method: 'apple',
-          merchantIdentifier: this.method.merchant_id,
-          validationURL: event.validationURL,
-          displayName: paymentRequest.total.label,
-          domainName: window.location.hostname,
+      account: {
+        email: shippingContact.emailAddress,
+      },
+      billing: {
+        method: 'apple',
+        account_card_id: null,
+        card: null,
+        apple: {
+          gateway: 'authorizenet',
+          token: base64Encode(JSON.stringify(token.paymentData)),
         },
-      });
-
-      if (merchantSession.error) {
-        console.error(
-          '[Apple Pay] Merchant validation error:',
-          merchantSession.error,
-        );
-        session.abort();
-        return;
-      }
-
-      if (merchantSession) {
-        session.completeMerchantValidation(merchantSession);
-      } else {
-        session.abort();
-      }
+        ...convertToSwellAddress(billingContact),
+      },
+      ...(requireShipping && {
+        shipping: convertToSwellAddress(shippingContact),
+      }),
     };
-
-    session.onshippingcontactselected = onShippingContactSelected.bind(
-      this,
-      session,
-    );
-
-    session.onshippingmethodselected = onShippingMethodSelected.bind(
-      this,
-      session,
-    );
-
-    session.oncouponcodechanged = onCouponCodeChanged.bind(this, session);
-
-    // PAYMENTAUTHORIZED: User confirmed payment with Face ID/Touch ID
-    // This is where we store the payment token in the cart
-    session.onpaymentauthorized = async (event) => {
-      try {
-        const {
-          payment: { token, shippingContact, billingContact },
-        } = event;
-
-        const { require: { shipping: requireShipping } = {} } = this.params;
-
-        // CRITICAL: Apple Pay addresses are the ONLY addresses we use
-        // - shippingContact: For shipping address (already validated in shippingcontactselected)
-        // - billingContact: For billing address (can be different from shipping)
-        // - email: From shippingContact.emailAddress
-        //
-        // We store the payment token but DO NOT process the order yet.
-        // The user must manually click "Place Order" to complete the transaction.
-        await this.updateCart({
-          account: {
-            email: shippingContact.emailAddress,
-          },
-          billing: {
-            method: 'apple',
-            account_card_id: null,
-            card: null,
-            apple: {
-              token: base64Encode(JSON.stringify(token.paymentData)),
-              gateway: 'authorizenet',
-            },
-            ...convertToSwellAddress(billingContact),
-          },
-          ...(requireShipping && {
-            shipping: convertToSwellAddress(shippingContact),
-          }),
-        });
-
-        // Complete Apple Pay session successfully
-        // This closes the Apple Pay sheet and shows success to the user
-        session.completePayment({
-          status: this.ApplePaySession.STATUS_SUCCESS,
-        });
-
-        // Notify that Apple Pay authorization is complete
-        // The cart now has the payment token and is ready for submission
-        // NOTE: This does NOT submit the order - user must click "Place Order"
-        this.onSuccess();
-      } catch (err) {
-        session.completePayment({
-          status: this.ApplePaySession.STATUS_FAILURE,
-          errors: new ApplePayError('unknown', undefined, err.message),
-        });
-
-        this.onError(err);
-      }
-    };
-
-    session.begin();
-  }
-
-  /** @param {ApplePayJS.ApplePayPaymentRequest} paymentRequest */
-  _createButton(paymentRequest) {
-    const { style: { type = 'plain', theme = 'black', height = '40px' } = {} } =
-      this.params;
-
-    const button = document.createElement('apple-pay-button');
-
-    button.setAttribute('buttonstyle', theme);
-    button.setAttribute('type', type);
-    button.style.setProperty('--apple-pay-button-width', '100%');
-    button.style.setProperty('--apple-pay-button-height', height);
-
-    button.addEventListener(
-      'click',
-      this._createPaymentSession.bind(this, paymentRequest),
-    );
-
-    return button;
-  }
-
-  /**
-   * Creates the Apple Pay button element
-   *
-   * The button is created but NOT clicked yet. When clicked, it will:
-   * 1. Create a new Apple Pay session
-   * 2. Open the Apple Pay sheet
-   * 3. Handle all payment events (address selection, authorization, etc.)
-   *
-   * @param {Cart} cart
-   */
-  async createElements(cart) {
-    const { elementId = 'applepay-button' } = this.params;
-
-    this.setElementContainer(elementId);
-    await this.loadScripts(this.scripts);
-
-    if (!this.ApplePaySession.canMakePayments()) {
-      throw new Error(
-        'This device is not capable of making Apple Pay payments',
-      );
-    }
-
-    const paymentRequest = this._createPaymentRequest(cart);
-
-    this.element = this._createButton(paymentRequest);
-  }
-
-  /**
-   * Mounts the Apple Pay button to the DOM
-   */
-  mountElements() {
-    const { classes = {} } = this.params;
-    const container = this.elementContainer;
-
-    container.appendChild(this.element);
-
-    if (classes.base) {
-      container.classList.add(classes.base);
-    }
   }
 }

--- a/src/payment/apple/convesiopay.js
+++ b/src/payment/apple/convesiopay.js
@@ -1,223 +1,169 @@
-import Payment from '../payment';
-
 import { isLiveMode } from '../../utils';
 
-import {
-  PaymentMethodDisabledError,
-  LibraryNotLoadedError,
-} from '../../utils/errors';
-
-import { amountInCents } from '../utils';
+import { convertToSwellAddress } from '../apple';
 
 import {
-  getTotal as getAppleTotal,
-  getLineItems as getAppleLineItems,
-  convertToSwellAddress,
-  onShippingAddressChange,
-  onShippingMethodChange,
-} from '../apple';
+  getBrowserInfo,
+  getBaseConvesioApiUrl,
+  getConvesioPaymentSettings,
+} from '../convesiopay';
+
+import AbstractApplePayment from './abstract';
 
 /** @typedef {import('../../../types').Cart} Cart */
 
-export default class ConvesioPayApplePayment extends Payment {
-  static convesioPay = null;
-  static convesioPayComponent = null;
-
+export default class ConvesioPayApplePayment extends AbstractApplePayment {
   constructor(api, options, params, methods) {
-    if (!methods.card) {
-      throw new PaymentMethodDisabledError('Credit cards');
-    }
-
-    super(api, options, params, methods.apple);
+    super(api, options, params, methods);
 
     this.convesiopay = methods.card;
   }
 
-  get scripts() {
-    return ['convesiopay-js'];
-  }
-
-  get convesioPay() {
-    if (ConvesioPayApplePayment.convesioPay === null) {
-      if (window.ConvesioPay) {
-        this.convesioPay = window.ConvesioPay(this.convesiopay.public_key);
-      }
-
-      if (!ConvesioPayApplePayment.convesioPay) {
-        throw new LibraryNotLoadedError('ConvesioPay');
-      }
-    }
-
-    return ConvesioPayApplePayment.convesioPay;
-  }
-
-  set convesioPay(convesioPay) {
-    ConvesioPayApplePayment.convesioPay = convesioPay;
-  }
-
-  get convesioPayComponent() {
-    return ConvesioPayApplePayment.convesioPayComponent;
-  }
-
-  set convesioPayComponent(convesioPayComponent) {
-    ConvesioPayApplePayment.convesioPayComponent = convesioPayComponent;
+  /**
+   * @override
+   * @returns {string[]}
+   */
+  getSupportedCardNetworks() {
+    return ['visa', 'masterCard', 'amex', 'discover'];
   }
 
   /**
-   * Creates the Apple Pay button element
-   *
+   * @override
+   * @returns {ApplePayJS.ApplePayMerchantCapability[]}
+   */
+  getMerchantCapabilities() {
+    return ['supports3DS'];
+  }
+
+  /**
+   * @override
    * @param {Cart} cart
    */
-  async createElements(cart) {
-    const { elementId = 'applepay-button' } = this.params;
+  async getApplePayMerchantInfo(cart) {
+    const settings = await getConvesioPaymentSettings(
+      this.method.mode,
+      this.convesiopay,
+      cart.settings?.country,
+    );
 
-    this.setElementContainer(elementId);
-    await this.loadScripts(this.scripts);
+    if (!settings) {
+      throw new Error('ConvesioPay payment settings not found');
+    }
 
-    this.convesioPayComponent = this.convesioPay.component({
-      environment: isLiveMode(this.method.mode) ? 'live' : 'test',
-      integration: this.convesiopay.integration,
-      customerEmail: cart.account?.email,
-      express: true,
-      disabledPaymentMethods: {
-        cards: true,
-        btcpay: true,
-        googlePay: true,
-      },
-    });
-
-    // When initiating a payment request,
-    // we should not display the shipping cost, as it will be calculated later.
-    cart = { ...cart };
-    cart.shipment_price = 0;
-    cart.shipping = {};
-
-    this.sessionOptions = {
-      integration: this.convesiopay.integration,
-      returnUrl: this.params.returnUrl,
-      amount: amountInCents(cart.currency, cart.capture_total),
-      currency: cart.currency,
-      shippingMethods: getShippingMethods(cart),
-      lineItems: getLineItems(cart),
+    this.merchantInfo = {
+      displayName: settings.statementDescriptor || cart.settings.name || '',
     };
   }
 
   /**
-   * Mounts the Apple Pay button to the DOM
+   * @override
+   * @param {ApplePayJS.ApplePayValidateMerchantEvent} event
    */
-  mountElements() {
-    const { classes = {} } = this.params;
-    const container = this.elementContainer;
+  async createMerchantSession(event) {
+    return createMerchantApplePaySession(
+      this.method.mode,
+      this.convesiopay,
+      event.validationURL,
+      this.merchantInfo.displayName,
+    );
+  }
 
-    this.convesioPayComponent.mount(`#${container.id}`);
+  /**
+   * @override
+   * @param {ApplePayJS.ApplePayPaymentAuthorizedEvent} event
+   * @returns {Promise<object>}
+   */
+  async preparePaymentDataForCartUpdate(event) {
+    const {
+      payment: { token, shippingContact, billingContact },
+    } = event;
 
-    if (classes.base) {
-      container.classList.add(classes.base);
-    }
+    const { require: { shipping: requireShipping } = {} } = this.params;
 
-    this.convesioPayComponent.createApplePaySession({
-      ...this.sessionOptions,
-      onShippingAddressChange: onShippingAddressChange.bind(this),
-      onShippingMethodChange: onShippingMethodChange.bind(this),
-      onPaymentMethodChange: async (_paymentMethod) => {
-        const currentCart = await this.getCart();
-
-        return {
-          newTotal: getAppleTotal(currentCart),
-          newLineItems: getAppleLineItems(currentCart),
-        };
+    const payment = await createConvesioApplePaymentToken(
+      this.method.mode,
+      this.convesiopay,
+      {
+        paymentMethod: {
+          type: 'applepay',
+        },
+        token: {
+          paymentData: token.paymentData,
+          paymentMethod: token.paymentMethod,
+          transactionIdentifier: token.transactionIdentifier,
+        },
+        browserInfo: getBrowserInfo(),
+        origin: window.location.origin,
+        billingContact: billingContact || undefined,
+        shippingContact: shippingContact || undefined,
       },
-    });
+    );
 
-    this.convesioPayComponent.on('change', async (event) => {
-      if (event.type === 'applepay') {
-        if (event.isSuccessful) {
-          const { token, shippingContact, billingContact } = event;
-          const { require: { shipping: requireShipping } = {} } = this.params;
-
-          await this.updateCart({
-            account: {
-              email: shippingContact.emailAddress,
-            },
-            billing: {
-              method: 'apple',
-              account_card_id: null,
-              card: null,
-              apple: {
-                token,
-                gateway: 'convesiopay',
-              },
-              ...convertToSwellAddress(billingContact),
-            },
-            ...(requireShipping && {
-              shipping: convertToSwellAddress(shippingContact),
-            }),
-          });
-        }
-      }
-    });
+    return {
+      account: {
+        email: shippingContact.emailAddress,
+      },
+      billing: {
+        method: 'apple',
+        account_card_id: null,
+        card: null,
+        apple: {
+          gateway: 'convesiopay',
+          token: payment.token || payment.paymentToken,
+        },
+        convesiopay: {
+          return_url: this.params.returnUrl,
+        },
+        ...convertToSwellAddress(billingContact),
+      },
+      ...(requireShipping && {
+        shipping: convertToSwellAddress(shippingContact),
+      }),
+    };
   }
 }
 
-/**
- * @param {Cart} cart
- * @returns {object[]}
- */
-function getLineItems(cart) {
-  const { sub_total, shipment_price, discount_total, tax_total, currency } =
-    cart;
+async function createMerchantApplePaySession(
+  mode,
+  settings,
+  validationURL,
+  displayName,
+) {
+  const baseUrl = getBaseConvesioApiUrl(mode);
 
-  /** @type {ApplePayJS.ApplePayLineItem[]} */
-  const lineItems = [
-    {
-      label: 'Subtotal',
-      amount: amountInCents(currency, sub_total || 0),
+  const response = await fetch(`${baseUrl}/v1/applepay/session`, {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+      'X-Api-Key': settings.public_key,
     },
-  ];
+    body: JSON.stringify({
+      validationURL,
+      displayName,
+      initiativeContext: window.location.hostname,
+    }),
+  });
 
-  if (shipment_price) {
-    lineItems.push({
-      label: 'Shipping',
-      amount: amountInCents(currency, shipment_price),
-    });
+  if (!response.ok) {
+    throw new Error(`Merchant validation failed: ${response.status}`);
   }
 
-  if (discount_total) {
-    lineItems.push({
-      label: 'Discount',
-      amount: amountInCents(currency, -discount_total),
-    });
-  }
-
-  if (tax_total) {
-    lineItems.push({
-      label: 'Taxes',
-      amount: amountInCents(currency, tax_total),
-    });
-  }
-
-  return lineItems;
+  return response.json();
 }
 
-/**
- * @param {Cart} cart
- * @returns {object[]}
- */
-function getShippingMethods(cart) {
-  const { shipment_delivery, shipment_rating, currency } = cart;
+function createConvesioApplePaymentToken(mode, settings, data) {
+  const baseUrl = isLiveMode(mode)
+    ? 'https://vault-apay.convesiopay.com'
+    : 'https://qa-vault-apay.convesiopay.com';
 
-  if (!shipment_delivery) {
-    return [];
-  }
-
-  if (!shipment_rating?.services?.length) {
-    return [];
-  }
-
-  return shipment_rating.services.map((service, index) => ({
-    label: service.name || `Shipping ${index + 1}`,
-    detail: service.description || '',
-    amount: amountInCents(currency, service.price || 0),
-    identifier: service.id,
-  }));
+  return fetch(`${baseUrl}/v1/create-token`, {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+      'X-Api-Key': settings.public_key,
+    },
+    body: JSON.stringify(data),
+  }).then((res) => res.json());
 }

--- a/src/payment/apple/convesiopay.js
+++ b/src/payment/apple/convesiopay.js
@@ -5,6 +5,7 @@ import { convertToSwellAddress } from '../apple';
 import {
   getBrowserInfo,
   getBaseConvesioApiUrl,
+  getConvesioErrorMessage,
   getConvesioPaymentSettings,
 } from '../convesiopay';
 
@@ -165,5 +166,13 @@ function createConvesioApplePaymentToken(mode, settings, data) {
       'X-Api-Key': settings.public_key,
     },
     body: JSON.stringify(data),
-  }).then((res) => res.json());
+  }).then(async (res) => {
+    if (!res.ok) {
+      throw new Error(
+        (await getConvesioErrorMessage(res)) || 'Failed to create token',
+      );
+    }
+
+    return res.json();
+  });
 }

--- a/src/payment/card/convesiopay.js
+++ b/src/payment/card/convesiopay.js
@@ -1,7 +1,11 @@
 import cardApi from '../../card';
 import { isLiveMode } from '../../utils';
 
-import { getBrowserInfo, getBaseConvesioApiUrl } from '../convesiopay';
+import {
+  getBrowserInfo,
+  getBaseConvesioApiUrl,
+  getConvesioErrorMessage,
+} from '../convesiopay';
 
 import Payment from '../payment';
 
@@ -101,7 +105,15 @@ function createConvesioCardPaymentToken(settings, data) {
       'X-Api-Key': settings.public_key,
     },
     body: JSON.stringify(data),
-  }).then((res) => res.json());
+  }).then(async (res) => {
+    if (!res.ok) {
+      throw new Error(
+        (await getConvesioErrorMessage(res)) || 'Failed to create token',
+      );
+    }
+
+    return res.json();
+  });
 }
 
 let cachedIp = null;

--- a/src/payment/card/convesiopay.js
+++ b/src/payment/card/convesiopay.js
@@ -1,72 +1,70 @@
+import cardApi from '../../card';
+import { isLiveMode } from '../../utils';
+
+import { getBrowserInfo, getBaseConvesioApiUrl } from '../convesiopay';
+
 import Payment from '../payment';
 
-import { isLiveMode } from '../../utils';
-import { LibraryNotLoadedError } from '../../utils/errors';
-
 export default class ConvesioCardPayment extends Payment {
-  static convesioPay = null;
-  static convesioPayComponent = null;
-
   constructor(api, options, params, methods) {
     super(api, options, params, methods.card);
   }
 
-  get scripts() {
-    return ['convesiopay-js'];
-  }
-
-  get convesioPay() {
-    if (ConvesioCardPayment.convesioPay === null) {
-      if (window.ConvesioPay) {
-        this.convesioPay = window.ConvesioPay(this.method.public_key);
-      }
-
-      if (!ConvesioCardPayment.convesioPay) {
-        throw new LibraryNotLoadedError('ConvesioPay');
-      }
-    }
-
-    return ConvesioCardPayment.convesioPay;
-  }
-
-  set convesioPay(convesioPay) {
-    ConvesioCardPayment.convesioPay = convesioPay;
-  }
-
-  get convesioPayComponent() {
-    return ConvesioCardPayment.convesioPayComponent;
-  }
-
-  set convesioPayComponent(convesioPayComponent) {
-    ConvesioCardPayment.convesioPayComponent = convesioPayComponent;
-  }
-
-  async createElements(cart) {
-    await this.loadScripts(this.scripts);
-
-    const component = this.convesioPay.component({
-      environment: isLiveMode(this.method.mode) ? 'live' : 'test',
-      integration: this.method.integration,
-      customerEmail: cart.account?.email,
-      express: false,
-      disabledPaymentMethods: {
-        btcpay: true,
-        applePay: true,
-        googlePay: true,
-      },
-    });
-
-    this.convesioPayComponent = component;
-
-    component.mount(`#${this.params.elementId || 'card-element'}`);
-  }
+  async createElements() {}
 
   async tokenize() {
-    if (!this.convesioPayComponent) {
-      throw new Error('ConvesioPay element is not defined');
-    }
+    const cardNumber = (
+      this.params.number ||
+      document.getElementById(
+        this.params.cardNumber?.elementId || 'cardNumber-element',
+      )?.value ||
+      ''
+    ).replace(/[^0-9]+/g, '');
 
-    const token = await this.convesioPayComponent.createToken();
+    const cardExpiry = cardApi.expiry(
+      this.params.exp ||
+        document.getElementById(
+          this.params.cardExpiry?.elementId || 'cardExpiry-element',
+        )?.value ||
+        '',
+    );
+
+    const cardCvc = (
+      this.params.cvc ||
+      document.getElementById(
+        this.params.cardCvc?.elementId || 'cardCvc-element',
+      )?.value ||
+      ''
+    ).trim();
+
+    const cardHolder = (
+      this.params.name ||
+      document.getElementById(
+        this.params.cardHolder?.elementId || 'cardHolder-element',
+      )?.value ||
+      ''
+    ).trim();
+
+    const cardBrand = cardApi.type(cardNumber).toLowerCase();
+
+    const payment = await createConvesioCardPaymentToken(this.method, {
+      paymentMethod: {
+        type: 'scheme',
+        brand: cardBrand,
+        last4: cardNumber.slice(-4),
+      },
+      origin: window.location.origin,
+      storePaymentMethod: true,
+      browserInfo: getBrowserInfo(),
+      shopperIp: await getShopperIp(),
+      number: cardNumber,
+      expiryDate: {
+        expiryMonth: String(cardExpiry.month).padStart(2, '0'),
+        expiryYear: String(cardExpiry.year).slice(-2),
+      },
+      cvc: cardCvc,
+      holderName: cardHolder,
+    });
 
     await this.updateCart({
       billing: {
@@ -74,11 +72,12 @@ export default class ConvesioCardPayment extends Payment {
         account_card_id: null,
         card: {
           gateway: 'convesiopay',
-          token,
-          last4: '????',
-          brand: null,
-          exp_month: null,
-          exp_year: null,
+          token: payment.token || payment.paymentToken,
+          last4: cardNumber.slice(-4),
+          brand: cardBrand,
+          exp_month: cardExpiry.month,
+          exp_year: cardExpiry.year,
+          test: isLiveMode(this.method.mode) ? undefined : true,
         },
         convesiopay: {
           return_url: this.params.returnUrl,
@@ -88,4 +87,51 @@ export default class ConvesioCardPayment extends Payment {
 
     return this.onSuccess();
   }
+}
+
+function createConvesioCardPaymentToken(settings, data) {
+  const baseUrl = getBaseConvesioApiUrl(settings.mode);
+
+  return fetch(`${baseUrl}/v1/create-token`, {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+      'X-Requested-With': 'convesio-pay-dashboard',
+      'X-Api-Key': settings.public_key,
+    },
+    body: JSON.stringify(data),
+  }).then((res) => res.json());
+}
+
+let cachedIp = null;
+
+function getShopperIp() {
+  // Return cached IP if available
+  if (cachedIp) {
+    return cachedIp;
+  }
+
+  // Fetch IP from ipify (free, no API key required)
+  return fetch('https://api.ipify.org?format=json', {
+    method: 'GET',
+    cache: 'no-store',
+  })
+    .then((response) => {
+      if (!response.ok) {
+        throw new Error('Failed to fetch IP');
+      }
+
+      return response.json();
+    })
+    .then(
+      (data) => {
+        cachedIp = data.ip;
+        return cachedIp;
+      },
+      (err) => {
+        console.err(err);
+        return null;
+      },
+    );
 }

--- a/src/payment/convesiopay.js
+++ b/src/payment/convesiopay.js
@@ -1,0 +1,60 @@
+import { isLiveMode } from '../utils';
+
+let convesioSettings = null;
+
+export function getBaseConvesioApiUrl(mode) {
+  return isLiveMode(mode)
+    ? 'https://api.convesiopay.com'
+    : 'https://api-qa.convesiopay.com';
+}
+
+export async function getConvesioPaymentSettings(mode, settings, country) {
+  if (convesioSettings !== null) {
+    return convesioSettings;
+  }
+
+  const baseUrl = getBaseConvesioApiUrl(mode);
+
+  convesioSettings = fetch(
+    `${baseUrl}/v1/payment-methods?integration=${encodeURIComponent(settings.integration)}`,
+    {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+        'X-Api-Key': settings.public_key,
+      },
+      body: JSON.stringify({
+        merchantAccount: false,
+        countryCode: country || 'US',
+        shopperLocale: 'en-US',
+        // shopperReference: email ? md5(email) : undefined,
+      }),
+    },
+  ).then((res) => res.json());
+
+  convesioSettings = await convesioSettings;
+
+  return convesioSettings;
+}
+
+export function getBrowserInfo() {
+  const screenWidth = window.screen?.width || 0;
+  const screenHeight = window.screen?.height || 0;
+  const colorDepth = window.screen?.colorDepth || 0;
+  const userAgent = window.navigator?.userAgent || '';
+  const javaEnabled = window.navigator?.javaEnabled?.() || false;
+  const language = window.navigator?.language || '';
+  const timeZoneOffset = new Date().getTimezoneOffset();
+
+  return {
+    acceptHeader: '*/*',
+    colorDepth,
+    language,
+    javaEnabled,
+    screenHeight,
+    screenWidth,
+    userAgent,
+    timeZoneOffset,
+  };
+}

--- a/src/payment/convesiopay.js
+++ b/src/payment/convesiopay.js
@@ -58,3 +58,16 @@ export function getBrowserInfo() {
     timeZoneOffset,
   };
 }
+
+/**
+ * @param {Response} response
+ * @returns {Promise<string>}
+ */
+export async function getConvesioErrorMessage(response) {
+  if (response.headers.get('content-type')?.includes('application/json')) {
+    const data = await response.json();
+    return data?.body?.message || '';
+  }
+
+  return '';
+}

--- a/src/payment/google/abstract.js
+++ b/src/payment/google/abstract.js
@@ -1,0 +1,296 @@
+import { isLiveMode } from '../../utils';
+
+import {
+  PaymentMethodDisabledError,
+  LibraryNotLoadedError,
+} from '../../utils/errors';
+
+import {
+  getOfferInfo,
+  getTransactionInfo,
+  getShippingOptionParameters,
+  onPaymentAuthorized,
+  onPaymentDataChanged,
+} from '../google';
+
+import Payment from '../payment';
+
+/** @typedef {import('../../../types').Cart} Cart */
+
+const API_VERSION = 2;
+const API_MINOR_VERSION = 0;
+
+export default class AbstractGooglePayment extends Payment {
+  constructor(api, options, params, methods) {
+    if (!methods.card) {
+      throw new PaymentMethodDisabledError('Credit cards');
+    }
+
+    super(api, options, params, methods.google);
+  }
+
+  get scripts() {
+    return ['google-pay'];
+  }
+
+  get google() {
+    if (!window.google) {
+      throw new LibraryNotLoadedError('Google');
+    }
+
+    return window.google;
+  }
+
+  /**
+   * Gets the Google Pay client instance, creating one if it doesn't exist.
+   * Each instance creates its own client to ensure proper callback binding.
+   * @returns {google.payments.api.PaymentsClient}
+   */
+  get googleClient() {
+    if (!this._googleClientInstance) {
+      if (this.google) {
+        this._googleClientInstance =
+          new this.google.payments.api.PaymentsClient({
+            environment: isLiveMode(this.method.mode) ? 'PRODUCTION' : 'TEST',
+            paymentDataCallbacks: {
+              onPaymentAuthorized: onPaymentAuthorized.bind(
+                this,
+                this._submitPayment.bind(this),
+              ),
+              onPaymentDataChanged: onPaymentDataChanged.bind(this),
+            },
+          });
+      }
+
+      if (!this._googleClientInstance) {
+        throw new LibraryNotLoadedError('Google client');
+      }
+    }
+
+    return this._googleClientInstance;
+  }
+
+  /**
+   * @param {Cart} cart
+   * @returns {Promise<google.payments.api.MerchantInfo>}
+   */
+  async getGooglePayMerchantInfo(cart) {
+    const {
+      settings: { name },
+    } = cart;
+
+    /** @type {google.payments.api.MerchantInfo} */
+    const merchantInfo = {
+      merchantName: name,
+    };
+
+    if (isLiveMode(this.method.mode)) {
+      merchantInfo.merchantId = this.method.merchant_id;
+    }
+
+    return merchantInfo;
+  }
+
+  /** @returns {google.payments.api.PaymentGatewayTokenizationParameters} */
+  getPaymentGatewayTokenizationParameters() {
+    throw new Error('Implement this!');
+  }
+
+  /** @returns {google.payments.api.CardNetwork[]} */
+  getAllowedCardNetworks() {
+    return ['AMEX', 'DISCOVER', 'INTERAC', 'JCB', 'MASTERCARD', 'VISA'];
+  }
+
+  /** @returns {google.payments.api.CardAuthMethod[]} */
+  getAllowedCardAuthMethods() {
+    return ['PAN_ONLY', 'CRYPTOGRAM_3DS'];
+  }
+
+  /**
+   * @param {boolean} [submit]
+   * @returns {google.payments.api.PaymentMethodSpecification}
+   */
+  _getCardPaymentMethod(submit = false) {
+    return {
+      type: 'CARD',
+      parameters: {
+        allowedAuthMethods: this.getAllowedCardAuthMethods(),
+        allowedCardNetworks: this.getAllowedCardNetworks(),
+        billingAddressRequired: true,
+        billingAddressParameters: {
+          format: 'FULL',
+          phoneNumberRequired: true,
+        },
+      },
+      ...(submit && {
+        tokenizationSpecification: {
+          type: 'PAYMENT_GATEWAY',
+          parameters: this.getPaymentGatewayTokenizationParameters(),
+        },
+      }),
+    };
+  }
+
+  /**
+   * @param {boolean} [submit]
+   * @returns {google.payments.api.PaymentMethodSpecification[]}
+   */
+  _getAllowedPaymentMethods(submit = false) {
+    return [this._getCardPaymentMethod(submit)];
+  }
+
+  /**
+   * Creates the payment data request object for Google Pay.
+   * @param {Cart} cart - The current cart data
+   * @param {google.payments.api.MerchantInfo} merchantInfo
+   * @returns {google.payments.api.PaymentDataRequest} Payment data request object
+   */
+  _createPaymentRequestData(cart, merchantInfo) {
+    cart = { ...cart };
+    // When initiating a payment request,
+    // we should not set the final price, otherwise problems may arise.
+    cart.shipment_price = 0;
+    cart.shipping = {};
+
+    const { shipment_delivery } = cart;
+    const { require: { email, shipping, phone } = {} } = this.params;
+
+    return {
+      apiVersion: API_VERSION,
+      apiVersionMinor: API_MINOR_VERSION,
+      transactionInfo: getTransactionInfo(cart),
+      allowedPaymentMethods: this._getAllowedPaymentMethods(true),
+      emailRequired: Boolean(email),
+      shippingAddressRequired: Boolean(shipping),
+      shippingAddressParameters: {
+        phoneNumberRequired: Boolean(phone),
+      },
+      shippingOptionRequired: Boolean(shipment_delivery),
+      shippingOptionParameters: getShippingOptionParameters.call(this, cart),
+      offerInfo: getOfferInfo(cart),
+      merchantInfo,
+      callbackIntents: [
+        'OFFER',
+        'SHIPPING_ADDRESS',
+        'SHIPPING_OPTION',
+        'PAYMENT_AUTHORIZATION',
+      ],
+    };
+  }
+
+  /**
+   * @param {google.payments.api.PaymentData} paymentData
+   * @returns {Promise<object>}
+   */
+  // eslint-disable-next-line no-unused-vars
+  async preparePaymentDataForCartUpdate(paymentData) {
+    throw new Error('Implement this!');
+  }
+
+  /** @param {google.payments.api.PaymentData} paymentData */
+  async _submitPayment(paymentData) {
+    const { paymentMethodData } = paymentData;
+
+    // Validate payment method data structure
+    if (
+      !paymentMethodData ||
+      !paymentMethodData.info ||
+      !paymentMethodData.tokenizationData
+    ) {
+      throw new Error('Invalid payment method data structure');
+    }
+
+    // Ensure token exists
+    if (!paymentMethodData.tokenizationData.token) {
+      throw new Error('Google Pay token is missing');
+    }
+
+    await this.preparePaymentDataForCartUpdate(paymentData).then((data) =>
+      this.updateCart(data),
+    );
+
+    this.onSuccess();
+  }
+
+  /**
+   * Handles the click event on the Google Pay button.
+   *
+   * @param {google.payments.api.PaymentDataRequest} paymentDataRequest
+   */
+  async _onClick(paymentDataRequest) {
+    try {
+      // This must be called directly from user gesture to avoid popup blockers
+      await this.googleClient.loadPaymentData(paymentDataRequest);
+    } catch (error) {
+      // Check if user closed the payment request
+      if (typeof error === 'object' && error !== null) {
+        if (error.statusCode === 'CANCELED') {
+          // User cancelled - this is not an error
+          return;
+        }
+      }
+
+      this.onError(error);
+    }
+  }
+
+  /** @param {Cart} cart */
+  async createElements(cart) {
+    const {
+      elementId = 'googlepay-button',
+      locale = 'en',
+      style: { color = 'black', type = 'plain', sizeMode = 'fill' } = {},
+    } = this.params;
+
+    this.setElementContainer(elementId);
+
+    const [merchantInfo] = await Promise.all([
+      this.getGooglePayMerchantInfo(cart),
+      this.loadScripts(this.scripts),
+    ]);
+
+    const isReadyToPay = await this.googleClient.isReadyToPay({
+      apiVersion: API_VERSION,
+      apiVersionMinor: API_MINOR_VERSION,
+      allowedPaymentMethods: this._getAllowedPaymentMethods(false),
+      existingPaymentMethodRequired: true,
+    });
+
+    if (!isReadyToPay.result) {
+      throw new Error(
+        'This device is not capable of making Google Pay payments',
+      );
+    }
+
+    const paymentDataRequest = this._createPaymentRequestData(
+      cart,
+      merchantInfo,
+    );
+
+    this.element = this.googleClient.createButton({
+      buttonColor: color,
+      buttonType: type,
+      buttonSizeMode: sizeMode,
+      buttonLocale: locale,
+      allowedPaymentMethods: this._getAllowedPaymentMethods(false),
+      onClick: this._onClick.bind(this, paymentDataRequest),
+    });
+
+    const button = this.element.querySelector('#gpay-button-online-api-id');
+
+    if (button) {
+      button.style['min-width'] = 'auto';
+    }
+  }
+
+  mountElements() {
+    const { classes = {} } = this.params;
+    const container = this.elementContainer;
+
+    container.appendChild(this.element);
+
+    if (classes.base) {
+      container.classList.add(classes.base);
+    }
+  }
+}

--- a/src/payment/google/authorizenet.js
+++ b/src/payment/google/authorizenet.js
@@ -25,7 +25,8 @@ export default class AuthorizeNetGooglePayment extends AbstractGooglePayment {
    */
   async preparePaymentDataForCartUpdate(paymentData) {
     const { require: { shipping: requireShipping } = {} } = this.params;
-    const { email, shippingAddress, paymentMethodData } = paymentData;
+    const { email, shippingAddress, shippingOptionData, paymentMethodData } =
+      paymentData;
 
     const {
       info: { billingAddress },
@@ -45,7 +46,10 @@ export default class AuthorizeNetGooglePayment extends AbstractGooglePayment {
         ...convertToSwellAddress(billingAddress),
       },
       ...(requireShipping && {
-        shipping: convertToSwellAddress(shippingAddress),
+        shipping: {
+          ...convertToSwellAddress(shippingAddress),
+          service: shippingOptionData?.id || undefined,
+        },
       }),
     };
   }

--- a/src/payment/google/authorizenet.js
+++ b/src/payment/google/authorizenet.js
@@ -1,187 +1,39 @@
-import Payment from '../payment';
-import {
-  getOfferInfo,
-  getTransactionInfo,
-  getShippingOptionParameters,
-  convertToSwellAddress,
-  onPaymentAuthorized,
-  onPaymentDataChanged,
-} from '../google';
-import { isLiveMode, base64Encode } from '../../utils';
-import {
-  PaymentMethodDisabledError,
-  LibraryNotLoadedError,
-} from '../../utils/errors';
+import { base64Encode } from '../../utils';
+
+import { convertToSwellAddress } from '../google';
+
+import AbstractGooglePayment from './abstract';
 
 /** @typedef {import('../../../types').Cart} Cart */
 
-const API_VERSION = 2;
-const API_MINOR_VERSION = 0;
-
-const ALLOWED_CARD_AUTH_METHODS = Object.freeze(['PAN_ONLY', 'CRYPTOGRAM_3DS']);
-
-const ALLOWED_CARD_NETWORKS = Object.freeze([
-  'AMEX',
-  'DISCOVER',
-  'INTERAC',
-  'JCB',
-  'MASTERCARD',
-  'VISA',
-]);
-
-export default class AuthorizeNetGooglePayment extends Payment {
-  constructor(api, options, params, methods) {
-    if (!methods.card) {
-      throw new PaymentMethodDisabledError('Credit cards');
-    }
-
-    super(api, options, params, methods.google);
-  }
-
-  get scripts() {
-    return ['google-pay'];
-  }
-
-  get google() {
-    if (!window.google) {
-      throw new LibraryNotLoadedError('Google');
-    }
-
-    return window.google;
-  }
-
+export default class AuthorizeNetGooglePayment extends AbstractGooglePayment {
   /**
-   * Gets the Google Pay client instance, creating one if it doesn't exist.
-   * Each instance creates its own client to ensure proper callback binding.
-   * @returns {google.payments.api.PaymentsClient}
+   * @override
+   * @returns {google.payments.api.PaymentGatewayTokenizationParameters}
    */
-  get googleClient() {
-    if (!this._googleClientInstance) {
-      if (this.google) {
-        this._googleClientInstance =
-          new this.google.payments.api.PaymentsClient({
-            environment: isLiveMode(this.method.mode) ? 'PRODUCTION' : 'TEST',
-            paymentDataCallbacks: {
-              onPaymentAuthorized: onPaymentAuthorized.bind(
-                this,
-                this._submitPayment.bind(this),
-              ),
-              onPaymentDataChanged: onPaymentDataChanged.bind(this),
-            },
-          });
-      }
-
-      if (!this._googleClientInstance) {
-        throw new LibraryNotLoadedError('Google client');
-      }
-    }
-
-    return this._googleClientInstance;
-  }
-
-  /**
-   * @param {boolean} [submit]
-   * @returns {google.payments.api.PaymentMethodSpecification}
-   */
-  _getCardPaymentMethod(submit = false) {
+  getPaymentGatewayTokenizationParameters() {
     return {
-      type: 'CARD',
-      parameters: {
-        allowedAuthMethods: ALLOWED_CARD_AUTH_METHODS,
-        allowedCardNetworks: ALLOWED_CARD_NETWORKS,
-        billingAddressRequired: true,
-        billingAddressParameters: {
-          format: 'FULL',
-          phoneNumberRequired: true,
-        },
-      },
-      ...(submit && {
-        tokenizationSpecification: {
-          type: 'PAYMENT_GATEWAY',
-          parameters: {
-            gateway: 'authorizenet',
-            gatewayMerchantId: this.method.gateway_merchant_id,
-          },
-        },
-      }),
+      gateway: 'authorizenet',
+      gatewayMerchantId: this.method.gateway_merchant_id,
     };
   }
 
   /**
-   * @param {boolean} [submit]
-   * @returns {google.payments.api.PaymentMethodSpecification[]}
+   * @override
+   * @param {google.payments.api.PaymentData} paymentData
+   * @returns {Promise<object>}
    */
-  _getAllowedPaymentMethods(submit = false) {
-    return [this._getCardPaymentMethod(submit)];
-  }
-
-  /**
-   * Creates the payment data request object for Google Pay.
-   * @param {Cart} cart - The current cart data
-   * @returns {google.payments.api.PaymentDataRequest} Payment data request object
-   */
-  _createPaymentRequestData(cart) {
-    const {
-      settings: { name },
-      shipment_delivery,
-    } = cart;
-
-    const { require: { email, shipping, phone } = {} } = this.params;
-
-    return {
-      apiVersion: API_VERSION,
-      apiVersionMinor: API_MINOR_VERSION,
-      transactionInfo: getTransactionInfo(cart),
-      allowedPaymentMethods: this._getAllowedPaymentMethods(true),
-      emailRequired: Boolean(email),
-      shippingAddressRequired: Boolean(shipping),
-      shippingAddressParameters: {
-        phoneNumberRequired: Boolean(phone),
-      },
-      shippingOptionRequired: Boolean(shipment_delivery),
-      shippingOptionParameters: getShippingOptionParameters.call(this, cart),
-      offerInfo: getOfferInfo(cart),
-      merchantInfo: {
-        merchantName: name,
-        merchantId: this.method.merchant_id,
-      },
-      callbackIntents: [
-        'OFFER',
-        'SHIPPING_ADDRESS',
-        'SHIPPING_OPTION',
-        'PAYMENT_AUTHORIZATION',
-      ],
-    };
-  }
-
-  /** @param {google.payments.api.PaymentData} paymentData */
-  async _submitPayment(paymentData) {
+  async preparePaymentDataForCartUpdate(paymentData) {
     const { require: { shipping: requireShipping } = {} } = this.params;
     const { email, shippingAddress, paymentMethodData } = paymentData;
-
-    // Validate payment method data structure
-    if (
-      !paymentMethodData ||
-      !paymentMethodData.info ||
-      !paymentMethodData.tokenizationData
-    ) {
-      throw new Error('Invalid payment method data structure');
-    }
 
     const {
       info: { billingAddress },
       tokenizationData: { token },
     } = paymentMethodData;
 
-    // Ensure token exists
-    if (!token) {
-      throw new Error('Payment token is missing');
-    }
-
-    await this.updateCart({
-      account: {
-        email,
-      },
+    return {
+      account: { email },
       billing: {
         method: 'google',
         account_card_id: null,
@@ -195,87 +47,6 @@ export default class AuthorizeNetGooglePayment extends Payment {
       ...(requireShipping && {
         shipping: convertToSwellAddress(shippingAddress),
       }),
-    });
-
-    this.onSuccess();
-  }
-
-  /**
-   * Handles the click event on the Google Pay button.
-   *
-   * @param {google.payments.api.PaymentDataRequest} paymentDataRequest
-   */
-  async _onClick(paymentDataRequest) {
-    try {
-      // This must be called directly from user gesture to avoid popup blockers
-      await this.googleClient.loadPaymentData(paymentDataRequest);
-    } catch (error) {
-      // Check if user closed the payment request
-      if (typeof error === 'object' && error !== null) {
-        if (error.statusCode === 'CANCELED') {
-          // User cancelled - this is not an error
-          return;
-        }
-      }
-
-      this.onError(error);
-    }
-  }
-
-  /** @param {Cart} cart */
-  async createElements(cart) {
-    const {
-      elementId = 'googlepay-button',
-      locale = 'en',
-      style: { color = 'black', type = 'plain', sizeMode = 'fill' } = {},
-    } = this.params;
-
-    if (!this.method.merchant_id) {
-      throw new Error('Google merchant ID is not defined');
-    }
-
-    this.setElementContainer(elementId);
-    await this.loadScripts(this.scripts);
-
-    const isReadyToPay = await this.googleClient.isReadyToPay({
-      apiVersion: API_VERSION,
-      apiVersionMinor: API_MINOR_VERSION,
-      allowedPaymentMethods: this._getAllowedPaymentMethods(false),
-      existingPaymentMethodRequired: true,
-    });
-
-    if (!isReadyToPay.result) {
-      throw new Error(
-        'This device is not capable of making Google Pay payments',
-      );
-    }
-
-    const paymentDataRequest = this._createPaymentRequestData(cart);
-
-    this.element = this.googleClient.createButton({
-      buttonColor: color,
-      buttonType: type,
-      buttonSizeMode: sizeMode,
-      buttonLocale: locale,
-      allowedPaymentMethods: this._getAllowedPaymentMethods(false),
-      onClick: this._onClick.bind(this, paymentDataRequest),
-    });
-
-    const button = this.element.querySelector('#gpay-button-online-api-id');
-
-    if (button) {
-      button.style['min-width'] = 'auto';
-    }
-  }
-
-  mountElements() {
-    const { classes = {} } = this.params;
-    const container = this.elementContainer;
-
-    container.appendChild(this.element);
-
-    if (classes.base) {
-      container.classList.add(classes.base);
-    }
+    };
   }
 }

--- a/src/payment/google/convesiopay.js
+++ b/src/payment/google/convesiopay.js
@@ -1,7 +1,12 @@
 import { isLiveMode } from '../../utils';
 
 import { convertToSwellAddress } from '../google';
-import { getBrowserInfo, getConvesioPaymentSettings } from '../convesiopay';
+
+import {
+  getBrowserInfo,
+  getConvesioErrorMessage,
+  getConvesioPaymentSettings,
+} from '../convesiopay';
 
 import AbstractGooglePayment from './abstract';
 
@@ -76,7 +81,8 @@ export default class ConvesioPayGooglePayment extends AbstractGooglePayment {
    */
   async preparePaymentDataForCartUpdate(paymentData) {
     const { require: { shipping: requireShipping } = {} } = this.params;
-    const { email, shippingAddress, paymentMethodData } = paymentData;
+    const { email, shippingAddress, shippingOptionData, paymentMethodData } =
+      paymentData;
 
     const {
       info: { billingAddress },
@@ -118,7 +124,10 @@ export default class ConvesioPayGooglePayment extends AbstractGooglePayment {
         ...convertToSwellAddress(billingAddress),
       },
       ...(requireShipping && {
-        shipping: convertToSwellAddress(shippingAddress),
+        shipping: {
+          ...convertToSwellAddress(shippingAddress),
+          service: shippingOptionData?.id || undefined,
+        },
       }),
     };
   }
@@ -145,7 +154,15 @@ function createConvesioGooglePaymentToken(mode, settings, data) {
       'X-Api-Key': settings.public_key,
     },
     body: JSON.stringify(data),
-  }).then((res) => res.json());
+  }).then(async (res) => {
+    if (!res.ok) {
+      throw new Error(
+        (await getConvesioErrorMessage(res)) || 'Failed to create token',
+      );
+    }
+
+    return res.json();
+  });
 }
 
 function normalizeGooglePayContact(address, email) {

--- a/src/payment/google/convesiopay.js
+++ b/src/payment/google/convesiopay.js
@@ -1,0 +1,180 @@
+import { isLiveMode } from '../../utils';
+
+import { convertToSwellAddress } from '../google';
+import { getBrowserInfo, getConvesioPaymentSettings } from '../convesiopay';
+
+import AbstractGooglePayment from './abstract';
+
+/** @typedef {import('../../../types').Cart} Cart */
+
+export default class ConvesioPayGooglePayment extends AbstractGooglePayment {
+  constructor(api, options, params, methods) {
+    super(api, options, params, methods);
+
+    this.convesiopay = methods.card;
+  }
+
+  /**
+   * @override
+   * @param {Cart} cart
+   * @returns {Promise<google.payments.api.MerchantInfo>}
+   */
+  async getGooglePayMerchantInfo(cart) {
+    const settings = await getConvesioPaymentSettings(
+      this.method.mode,
+      this.convesiopay,
+      cart.settings?.country,
+    );
+
+    if (!settings) {
+      throw new Error('ConvesioPay payment settings not found');
+    }
+
+    /** @type {google.payments.api.MerchantInfo} */
+    const merchantInfo = {
+      merchantName: settings.statementDescriptor,
+    };
+
+    if (isLiveMode(this.method.mode)) {
+      merchantInfo.merchantId = settings.integrations?.gpay?.merchantId;
+    }
+
+    return merchantInfo;
+  }
+
+  /**
+   * @override
+   * @returns {google.payments.api.PaymentGatewayTokenizationParameters}
+   */
+  getPaymentGatewayTokenizationParameters() {
+    return {
+      gateway: 'verygoodsecurity',
+      gatewayMerchantId: 'ACqLMqto2f7TqDE8MDrnd9Dv',
+    };
+  }
+
+  /**
+   * @override
+   * @returns {google.payments.api.CardNetwork[]}
+   */
+  getAllowedCardNetworks() {
+    return ['AMEX', 'DISCOVER', 'JCB', 'MASTERCARD', 'VISA'];
+  }
+
+  /**
+   * @override
+   * @returns {google.payments.api.CardAuthMethod[]}
+   */
+  getAllowedCardAuthMethods() {
+    return ['PAN_ONLY', 'CRYPTOGRAM_3DS'];
+  }
+
+  /**
+   * @override
+   * @param {google.payments.api.PaymentData} paymentData
+   * @returns {Promise<object>}
+   */
+  async preparePaymentDataForCartUpdate(paymentData) {
+    const { require: { shipping: requireShipping } = {} } = this.params;
+    const { email, shippingAddress, paymentMethodData } = paymentData;
+
+    const {
+      info: { billingAddress },
+      tokenizationData: { token },
+    } = paymentMethodData;
+
+    const payment = await createConvesioGooglePaymentToken(
+      this.method.mode,
+      this.convesiopay,
+      {
+        paymentMethod: {
+          type: 'googlepay',
+        },
+        google_pay_payload: {
+          token: parseJsonToken(token),
+        },
+        browserInfo: getBrowserInfo(),
+        origin: window.location.origin,
+        billingContact:
+          normalizeGooglePayContact(billingAddress, null) || undefined,
+        shippingContact:
+          normalizeGooglePayContact(shippingAddress, email) || undefined,
+      },
+    );
+
+    return {
+      account: { email },
+      billing: {
+        method: 'google',
+        account_card_id: null,
+        card: null,
+        google: {
+          gateway: 'convesiopay',
+          token: payment.token || payment.paymentToken,
+        },
+        convesiopay: {
+          return_url: this.params.returnUrl,
+        },
+        ...convertToSwellAddress(billingAddress),
+      },
+      ...(requireShipping && {
+        shipping: convertToSwellAddress(shippingAddress),
+      }),
+    };
+  }
+}
+
+function parseJsonToken(token) {
+  try {
+    return JSON.parse(token);
+  } catch {
+    return token;
+  }
+}
+
+function createConvesioGooglePaymentToken(mode, settings, data) {
+  const baseUrl = isLiveMode(mode)
+    ? 'https://vault-gpay.convesiopay.com'
+    : 'https://qa-vault-gpay.convesiopay.com';
+
+  return fetch(`${baseUrl}/v1/create-token`, {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+      'X-Api-Key': settings.public_key,
+    },
+    body: JSON.stringify(data),
+  }).then((res) => res.json());
+}
+
+function normalizeGooglePayContact(address, email) {
+  if (!address) return null;
+
+  const nameParts = (address.name || '').trim().split(/\s+/);
+  const givenName = nameParts[0] || '';
+  const familyName = nameParts.slice(1).join(' ') || '';
+
+  const addressLines = [
+    address.address1,
+    address.address2,
+    address.address3,
+  ].filter(Boolean);
+
+  return {
+    givenName,
+    familyName,
+    addressLines,
+    locality: address.locality || '',
+    administrativeArea: address.administrativeArea || '',
+    country: address.countryCode || '',
+    countryCode: address.countryCode || '',
+    postalCode: address.postalCode || '',
+    subAdministrativeArea: '',
+    subLocality: '',
+    phoneticGivenName: '',
+    phoneticFamilyName: '',
+    ...(email && { emailAddress: email }),
+    ...(address.phoneNumber && { phoneNumber: address.phoneNumber }),
+  };
+}

--- a/src/payment/index.js
+++ b/src/payment/index.js
@@ -13,6 +13,7 @@ import AuthorizeNetApplePayment from './apple/authorizenet';
 import QuickpayCardPayment from './card/quickpay';
 import ConvesioCardPayment from './card/convesiopay';
 import ConvesioPayApplePayment from './apple/convesiopay';
+import ConvesioPayGooglePayment from './google/convesiopay';
 import PaysafecardDirectPayment from './paysafecard/paysafecard';
 import KlarnaDirectPayment from './klarna/klarna';
 import PaypalDirectPayment from './paypal/paypal';
@@ -363,6 +364,8 @@ export default class PaymentController {
         return BraintreeGooglePayment;
       case 'authorizenet':
         return AuthorizeNetGooglePayment;
+      case 'convesiopay':
+        return ConvesioPayGooglePayment;
       default:
         return null;
     }

--- a/src/utils/script-loader.js
+++ b/src/utils/script-loader.js
@@ -11,7 +11,6 @@ const SCRIPT_HANDLERS = {
   'braintree-google-payment': loadBraintreeGoogle,
   'braintree-apple-payment': loadBraintreeApple,
   'amazon-checkout': loadAmazonCheckout,
-  'convesiopay-js': loadConvesioPay,
   'sezzle-sdk': loadSezzleCheckout,
 };
 
@@ -177,16 +176,6 @@ async function loadAmazonCheckout() {
 
   if (!window.amazon) {
     console.error('Warning: Amazon Checkout was not loaded');
-  }
-}
-
-async function loadConvesioPay() {
-  if (!window.ConvesioPay) {
-    await loadScript('convesiopay-js', 'https://js.convesiopay.com/v1/');
-  }
-
-  if (!window.ConvesioPay) {
-    console.error('Warning: ConvesioPay was not loaded');
   }
 }
 


### PR DESCRIPTION
https://app.asana.com/1/1126683767705082/project/1203548350351764/task/1213641566265386?focus=true

Implement Google Pay for ConvesioPay gateway.

The Apple Pay and Google Pay implementation code has been refactored. Now we have abstract classes that can be easily extended for a specific gateway. The Apple Pay abstract class is used for the AuhtorizeNet and ConvesioPay gateway. The same was done for Google Pay.

Use direct requests to ConvesioPay to tokenize card. Remove `convesiopay-js` from script loader.

Fill in the card details with `last4`, `brand`, `exp_month`, `exp_year` and test flag.

Fix calculation of the card expiration date. Dates in the next century were considered invalid.
